### PR TITLE
Update README instructions and bazel BUILD file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,19 @@ design](https://docs.google.com/document/d/1Oi9EO3Jwtp69obakl-9YpLkP764GZzsz95XJ
 
 ## Prerequisites
 
-You must have a recent verzion of [bazel](https://bazel.io) installed. Bazel is
+You must have a recent version of [bazel](https://bazel.io) installed. Bazel is
 the recommended way to build and test the cluster registry. Bazel is designed to
 maintain compatibility with standard Go tooling, but this is not tested on a
 regular basis, and some scripts/tooling in this project are built around Bazel.
 
+You will need the [Mercurial](https://www.mercurial-scm.org/) `hg` CLI command
+installed in order to have Bazel install some of the dependencies.
+
 Before doing any development work, you must (in order, from the repository root
 directory, after cloning):
 
-*   run `update-genfiles.sh`
-*   run `bazel run //:gazelle`
+1.  run `update-codegen.sh`
+1.  run `bazel run //:gazelle`
 
 ## Building crinit
 
@@ -35,11 +38,11 @@ From the root of the repository:
 
 ## Building clusterregistry
 
-1.  Run `bazel build //cmd/clusterreigstry`
-1.  If you want to build a docker image, run `blaze build
-    //cmd/clusterregistry-image`
-1.  To push an image to Google Container registry, you'll need to run `blaze run
-    //cmd/push-clusterregistry-image --define project=<your_project_id>`
+1.  Run `bazel build //cmd/clusterregistry`
+1.  If you want to build a docker image, run `bazel build
+    //cmd/clusterregistry:clusterregistry-image`
+1.  To push an image to Google Container registry, you'll need to run `bazel run
+    //cmd/clusterregistry:push-clusterregistry-image --define project=<your_project_id>`
 
 ## Run all tests
 

--- a/cmd/clusterregistry/BUILD.bazel
+++ b/cmd/clusterregistry/BUILD.bazel
@@ -11,6 +11,6 @@ docker_push(
     name = "push-clusterregistry-image",
     image = ":clusterregistry-image",
     registry = "gcr.io",
-    repository = "kubetest-157500/clusterregistry",
+    repository = "$(project)/clusterregistry",
     tag = "dev",
 )


### PR DESCRIPTION
I started going through the README to build the binaries and container images and ran into some issues fixed here:

1. Update script name
1. Update build and run commands
1. Update bazel BUILD file to allow specifying `project` to upload container image
1. Update generated bazel BUILD file
1. Typos

I also ran into an issue because I was missing the Mercurial `hg` CLI tool due to a [bitbucket dependency for `bitbucket.org/ww/goautoneg`](https://github.com/kubernetes/apiserver/blob/b2a8ad67a002d27c8945573abb80b4be543f2a1f/Godeps/Godeps.json#L10) since we have [k8s.io/apiserver in our WORKSPACE dependency](https://github.com/kubernetes/cluster-registry/blob/94f78f21436ae2a8b24ca0fb8d07001c5b7cd52d/WORKSPACE#L61-L67). Installing Mercurial fixed the problem but I'm thinking that should have been handled for me.