### PR TITLE
 Remove the need for Mercurial to be installed by depending on an HTTP archive instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ NOTE: There is an issue with version bazel 0.6.0. As a workaround, use 0.5.x, or
 pass the flag `--incompatible_comprehension_variables_do_not_leak=false` to bazel
 0.6.0 invocations.
 
-You will need the [Mercurial](https://www.mercurial-scm.org/) `hg` CLI command
-installed in order to have Bazel install some of the dependencies.
-
 Before doing any development work, you must (in order, from the repository root
 directory, after cloning):
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -391,8 +391,9 @@ go_repository(
 
 go_repository(
     name = "org_bitbucket_ww_goautoneg",
-    commit = "75cd24fc2f2c2a2088577d12123ddee5f54e0675",
     importpath = "bitbucket.org/ww/goautoneg",
+    strip_prefix = "ww-goautoneg-75cd24fc2f2c",
+    urls = ["https://bitbucket.org/ww/goautoneg/get/75cd24fc2f2c.zip"],
 )
 
 go_repository(


### PR DESCRIPTION
Tested by removing the hg command from the PATH and running `bazel fetch`.