### PR TITLE
Uncomment a block that configures the API server with authentication options.

### DIFF
--- a/cmd/clusterregistry/app/server.go
+++ b/cmd/clusterregistry/app/server.go
@@ -86,9 +86,9 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 	if err := s.SecureServing.ApplyTo(genericConfig); err != nil {
 		return err
 	}
-	//if err := s.Authentication.ApplyTo(genericConfig); err != nil {
-	//	return err
-	//}
+	if err := s.Authentication.ApplyTo(genericConfig); err != nil {
+		return err
+	}
 	if err := s.Audit.ApplyTo(genericConfig); err != nil {
 		return err
 	}


### PR DESCRIPTION
Without this, the API server will not authorize any requests.

cc @font @madhusudancs