### PR TITLE
 Add a basic integration test for the cluster registry

### DIFF
--- a/pkg/clusterregistry/options/options.go
+++ b/pkg/clusterregistry/options/options.go
@@ -33,7 +33,6 @@ type ServerRunOptions struct {
 	SecureServing           *genericoptions.SecureServingOptions
 	Audit                   *genericoptions.AuditOptions
 	Features                *genericoptions.FeatureOptions
-	Admission               *genericoptions.AdmissionOptions
 	Authentication          *BuiltInAuthenticationOptions
 
 	EventTTL time.Duration
@@ -47,7 +46,6 @@ func NewServerRunOptions() *ServerRunOptions {
 		SecureServing:  genericoptions.NewSecureServingOptions(),
 		Audit:          genericoptions.NewAuditOptions(),
 		Features:       genericoptions.NewFeatureOptions(),
-		Admission:      genericoptions.NewAdmissionOptions(),
 		Authentication: NewBuiltInAuthenticationOptions().WithAll(),
 
 		EventTTL: 1 * time.Hour,
@@ -64,7 +62,6 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 	s.Audit.AddFlags(fs)
 	s.Features.AddFlags(fs)
 	s.Authentication.AddFlags(fs)
-	s.Admission.AddFlags(fs)
 
 	fs.DurationVar(&s.EventTTL, "event-ttl", s.EventTTL, "Amount of time to retain events.")
 }

--- a/pkg/clusterregistry/options/validation.go
+++ b/pkg/clusterregistry/options/validation.go
@@ -35,9 +35,6 @@ func (options *ServerRunOptions) Validate() []error {
 	if errs := options.Features.Validate(); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
-	if errs := options.Admission.Validate(); len(errs) > 0 {
-		errors = append(errors, errs...)
-	}
 	if options.EventTTL <= 0 {
 		errors = append(errors, fmt.Errorf("--event-ttl must be greater than 0"))
 	}

--- a/pkg/clusterregistry/server.go
+++ b/pkg/clusterregistry/server.go
@@ -120,13 +120,6 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 		return fmt.Errorf("failed to create clientset: %v", err)
 	}
 
-	sharedInformers := informers.NewSharedInformerFactory(client, genericConfig.LoopbackClientConfig.Timeout)
-
-	err = s.Admission.ApplyTo(genericConfig, nil, nil, nil, install.Scheme)
-	if err != nil {
-		return fmt.Errorf("failed to initialize plugins: %v", err)
-	}
-
 	genericConfig.Version = &version.Info{
 		Major: "0",
 		Minor: "1",
@@ -148,6 +141,7 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 	apiResourceConfigSource := storageFactory.APIResourceConfigSource
 	installClusterAPIs(m, genericConfig.RESTOptionsGetter, apiResourceConfigSource)
 
+	sharedInformers := informers.NewSharedInformerFactory(client, genericConfig.LoopbackClientConfig.Timeout)
 	err = m.PrepareRun().NonBlockingRun(stopCh)
 	if err == nil {
 		sharedInformers.Start(stopCh)

--- a/pkg/clusterregistry/testing/BUILD.bazel
+++ b/pkg/clusterregistry/testing/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["testserver.go"],
+    importpath = "k8s.io/cluster-registry/pkg/clusterregistry/testing",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/clusterregistry/install:go_default_library",
+        "//pkg/clusterregistry:go_default_library",
+        "//pkg/clusterregistry/options:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/etcd/testing:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["server_test.go"],
+    importpath = "k8s.io/cluster-registry/pkg/clusterregistry/testing",
+    library = ":go_default_library",
+    deps = [
+        "//pkg/apis/clusterregistry/v1alpha1:go_default_library",
+        "//pkg/client/clientset_generated/clientset:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/pkg/clusterregistry/testing/server_test.go
+++ b/pkg/clusterregistry/testing/server_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
+	crclientset "k8s.io/cluster-registry/pkg/client/clientset_generated/clientset"
+)
+
+func TestCreateAndGet(t *testing.T) {
+	config, tearDown := StartTestServerOrDie(t)
+	defer tearDown()
+
+	clientset, err := crclientset.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	_, err = clientset.ClusterregistryV1alpha1().Clusters().Create(&v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+	})
+
+	cluster, err := clientset.ClusterregistryV1alpha1().Clusters().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if cluster == nil {
+		t.Fatalf("Expected a cluster, got nil")
+	}
+	if cluster.Name != "cluster" {
+		t.Fatalf("Expected a cluster named 'cluster', got a cluster named '%v.", cluster.Name)
+	}
+}

--- a/pkg/clusterregistry/testing/testserver.go
+++ b/pkg/clusterregistry/testing/testserver.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/cluster-registry/pkg/apis/clusterregistry/install"
+	"k8s.io/cluster-registry/pkg/clusterregistry"
+	"k8s.io/cluster-registry/pkg/clusterregistry/options"
+)
+
+// TearDownFunc is to be called to tear down a test server.
+type TearDownFunc func()
+
+// StartTestServerOrDie calls startTestServer with up to 5 retries on bind error
+// and dies with t.Fatal if it does not succeed.
+func StartTestServerOrDie(t *testing.T) (*restclient.Config, TearDownFunc) {
+	// Retry starting the server because the bind might fail due to a race with
+	// another process binding to the port. We cannot listen to :0 (then the
+	// kernel would give us a port which is free for sure), so we need this
+	// workaround.
+	for retry := 0; retry < 5 && !t.Failed(); retry++ {
+		config, td, err := startTestServer(t)
+		if err == nil {
+			return config, td
+		}
+		if !strings.Contains(err.Error(), "bind") {
+			t.Fatalf("Failed to launch server: %v", err)
+		}
+		t.Logf("Bind error, retrying...")
+	}
+
+	t.Fatalf("Failed to launch server")
+	return nil, nil
+}
+
+// startTestServer starts an etcd server and cluster registry API server.
+// Returns a REST client config and a tear-down function.
+//
+// Note: we return a tear-down func instead of a stop channel because the latter
+//       will leak temporary files because Golang testing's call to os.Exit will
+//       not give a stop channel go routine enough time to remove temporary
+//       files.
+func startTestServer(t *testing.T) (result *restclient.Config, tearDownForCaller TearDownFunc, err error) {
+	var tmpDir string
+	var etcdServer *etcdtesting.EtcdTestServer
+	stopCh := make(chan struct{})
+	tearDown := func() {
+		close(stopCh)
+		if etcdServer != nil {
+			etcdServer.Terminate(t)
+		}
+		if len(tmpDir) != 0 {
+			os.RemoveAll(tmpDir)
+		}
+	}
+	defer func() {
+		if tearDownForCaller == nil {
+			tearDown()
+		}
+	}()
+
+	t.Logf("Starting etcd...")
+	etcdServer, storageConfig := etcdtesting.NewUnsecuredEtcd3TestClientServer(t, install.Scheme)
+
+	tmpDir, err = ioutil.TempDir("", "cluster-registry-clusterregistry-apiserver")
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create temp dir: %v", err)
+	}
+	port, err := freePort()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to find a free port: %v", err)
+	}
+	s := options.NewServerRunOptions()
+	s.SecureServing.BindPort = port
+	s.SecureServing.ServerCert.CertDirectory = tmpDir
+	s.Etcd.StorageConfig = *storageConfig
+	s.Etcd.DefaultStorageMediaType = "application/json"
+
+	t.Logf("Starting cluster registry...")
+	server, err := clusterregistry.CreateServer(s)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create server: %v", err)
+	}
+	runErrCh := make(chan error, 1)
+	go func(stopCh <-chan struct{}) {
+		if err := server.PrepareRun().Run(stopCh); err != nil {
+			t.Logf("cluster registry exited uncleanly: %v", err)
+			runErrCh <- err
+		}
+	}(stopCh)
+
+	t.Logf("Creating a new client for cluster registry API server...")
+	client, err := kubernetes.NewForConfig(server.LoopbackClientConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create a client: %v", err)
+	}
+	t.Logf("Waiting for /healthz to be OK...")
+	err = wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+		select {
+		case err := <-runErrCh:
+			return false, err
+		default:
+		}
+
+		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do()
+		status := 0
+		result.StatusCode(&status)
+		return status == http.StatusOK, nil
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("/healthz failed to return OK: %v", err)
+	}
+
+	return server.LoopbackClientConfig, tearDown, nil
+}
+
+// freePort finds and returns a free port on the local machine. Will return -1
+// for the port if there is an error.
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return -1, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}


### PR DESCRIPTION
This is based on work done for the kube-apiserver in [k/k/46865](https://github.com/kubernetes/kubernetes/pull/46865).