### PR TITLE
docker-credential-gcr needed for push to GCR

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -11,8 +11,13 @@ NOTE: There is an issue with bazel 0.6.x. As a workaround, use 0.5.x, or pass
 the flag `--incompatible_comprehension_variables_do_not_leak=false` to bazel
 0.6.x invocations.
 
-To push an image to Google Container registry you'll also have to have [docker-credential-gcr](https://github.com/GoogleCloudPlatform/docker-credential-gcr#building-from-source) installed and configured. This allows  
-for Docker clients v1.11+ to easily make authenticated requests to GCR's repositories (gcr.io, eu.gcr.io, etc.).
+To push an image to Google Container registry you'll also have to have 
+`docker-credential-gcr`installed and configured. This allows for Docker clients 
+v1.11+ to easily make authenticated requests to GCR's repositories (gcr.io, 
+eu.gcr.io, etc.):
+
+1. Install `gcloud components install docker-credential-gcr`
+1. Configure `docker-credential-gcr configure-docker`
 
 You'll need to clone the repository before doing any work. It's expedient to
 clone into $GOPATH/src/k8s.io/cluster-registry, since some Kubernetes and go

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,6 +11,9 @@ NOTE: There is an issue with bazel 0.6.x. As a workaround, use 0.5.x, or pass
 the flag `--incompatible_comprehension_variables_do_not_leak=false` to bazel
 0.6.x invocations.
 
+To push an image to Google Container registry you'll also have to have [docker-credential-gcr](https://github.com/GoogleCloudPlatform/docker-credential-gcr#building-from-source) installed and configured. This allows  
+for Docker clients v1.11+ to easily make authenticated requests to GCR's repositories (gcr.io, eu.gcr.io, etc.).
+
 You'll need to clone the repository before doing any work. It's expedient to
 clone into $GOPATH/src/k8s.io/cluster-registry, since some Kubernetes and go
 tooling expect this, but the repository itself is location-agnostic.

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,13 +11,13 @@ NOTE: There is an issue with bazel 0.6.x. As a workaround, use 0.5.x, or pass
 the flag `--incompatible_comprehension_variables_do_not_leak=false` to bazel
 0.6.x invocations.
 
-To push an image to Google Container registry you'll also have to have 
-`docker-credential-gcr`installed and configured. This allows for Docker clients 
+To push an image to Google Container Registry you'll also have to have 
+`docker-credential-gcr` installed and configured. This allows for Docker clients 
 v1.11+ to easily make authenticated requests to GCR's repositories (gcr.io, 
 eu.gcr.io, etc.):
 
-1. Install `gcloud components install docker-credential-gcr`
-1. Configure `docker-credential-gcr configure-docker`
+1. Run `gcloud components install docker-credential-gcr`
+1. Run `docker-credential-gcr configure-docker`
 
 You'll need to clone the repository before doing any work. It's expedient to
 clone into $GOPATH/src/k8s.io/cluster-registry, since some Kubernetes and go


### PR DESCRIPTION
I ran into a python error when trying to push to GCR without docker-credential-gcr installed. I propose that it be added to the prerequisites.
Another potential addition is `go get apimachinery` which I did not have installed prior to attempting to build cluster registry and caused my build to fail. I still am not sure what apimachinery is/does and why it would/wouldn't be installed anyway. I am happy to add this to the prerequisites too if it makes sense.