### PR TITLE
Add a script that can be used to run CI jobs for bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-bazel-*
+/bazel-*
 pkg/client/*generated
 pkg/apis/clusterregistry/**/*generated*
 BUILD.bazel

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,9 +6,11 @@ go_prefix("k8s.io/cluster-registry")
 
 # Dummy rule that allows the codegen script to fetch the dependencies it needs.
 filegroup(
-    name = "genfiles_dummy",
+    name = "genfiles_deps",
     srcs = [
+        "@io_k8s_apimachinery//pkg/conversion:go_default_library",
         "@io_k8s_apimachinery//pkg/fields:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_kubernetes//hack/boilerplate:boilerplate.go.txt",
     ],
 )

--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generates all necessary files and runs bazel test against the targets in
+# the repository.
+#
+# This is meant to be used from a Kubernetes test-infra execute scenario, as
+# defined here:
+# https://github.com/kubernetes/test-infra/blob/master/scenarios/execute.py
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd "${SCRIPT_ROOT}/.."
+hack/update-codegen.sh
+bazel run //:gazelle
+../test-infra/scenarios/kubernetes_bazel.py --test="//... -//pkg/client/... -//cmd/clusterregistry:push-clusterregistry-image"

--- a/hack/gopath_from_workspace.sh
+++ b/hack/gopath_from_workspace.sh
@@ -25,7 +25,7 @@
 
 set -euo pipefail
 
-bazel fetch //:genfiles_dummy
+bazel fetch //:genfiles_deps
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 TMP_GOPATH="$1"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -89,6 +89,7 @@ function generate_group() {
   echo "generating conversions"
   bazel run @io_k8s_code_generator//cmd/conversion-gen -- \
     --input-dirs ${APIS_PKG}/${GROUP_NAME},${APIS_PKG}/${GROUP_NAME}/${VERSION} \
+    --extra-peer-dirs "k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/conversion,k8s.io/apimachinery/pkg/runtime" \
     --output-base ${GEN_TMPDIR} \
     --output-file-base zz_generated.conversion
 


### PR DESCRIPTION
Also, fix an(other) issue with update-codegen by explicitly setting the `--extra-peer-dirs` and ensuring that they are fetched before the generation command is run.

cc @madhusudancs @font 