### PR TITLE
cmd/clusterregistry: fix BUILD file using gazelle

### DIFF
--- a/cmd/clusterregistry/BUILD.bazel
+++ b/cmd/clusterregistry/BUILD.bazel
@@ -14,3 +14,25 @@ docker_push(
     repository = "$(project)/clusterregistry",
     tag = "dev",
 )
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["clusterregistry.go"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/clusterregistry:go_default_library",
+        "//pkg/clusterregistry/options:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
+        "@io_k8s_apiserver//pkg/util/flag:go_default_library",
+        "@io_k8s_apiserver//pkg/util/logs:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "clusterregistry",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
cc @perotinus master looks broken.

```
$ bazel build //cmd/clusterregistry              
INFO: Found 1 target...                                                                                                
ERROR: missing input file '//cmd/clusterregistry:clusterregistry'.                   
ERROR: /home/eric/src/k8s.io/cluster-registry/cmd/clusterregistry/BUILD.bazel:3:1: //cmd/clusterregistry:clusterregistry: missing input file '//cmd/clusterregistry:clusterregistry'.
ERROR: /home/eric/src/k8s.io/cluster-registry/cmd/clusterregistry/BUILD.bazel:3:1 1 input file(s) do not exist.                                                                                                                              
INFO: Elapsed time: 0.186s, Critical Path: 0.00s      
```

Ran gazelle to update the BUILD file. We should probably have a hack file for this (`./hack/update-bazel.sh`)