### PR TITLE
Update the cluster-registry dependencies to newer versions.

### DIFF
--- a/pkg/clusterregistry/options/options.go
+++ b/pkg/clusterregistry/options/options.go
@@ -22,7 +22,6 @@ import (
 
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
-	"k8s.io/cluster-registry/pkg/apis/clusterregistry/install"
 
 	"github.com/spf13/pflag"
 )
@@ -44,7 +43,7 @@ type ServerRunOptions struct {
 func NewServerRunOptions() *ServerRunOptions {
 	o := &ServerRunOptions{
 		GenericServerRunOptions: genericoptions.NewServerRunOptions(),
-		Etcd:           genericoptions.NewEtcdOptions(storagebackend.NewDefaultConfig("/registry/clusterregistry.kubernetes.io", install.Scheme, nil)),
+		Etcd:           genericoptions.NewEtcdOptions(storagebackend.NewDefaultConfig("/registry/clusterregistry.kubernetes.io", nil)),
 		SecureServing:  genericoptions.NewSecureServingOptions(),
 		Audit:          genericoptions.NewAuditOptions(),
 		Features:       genericoptions.NewFeatureOptions(),

--- a/pkg/registry/cluster/etcd/etcd.go
+++ b/pkg/registry/cluster/etcd/etcd.go
@@ -31,7 +31,6 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against clusters.
 func NewREST(optsGetter generic.RESTOptionsGetter, scheme *runtime.Scheme) (*REST, error) {
 	store := &genericregistry.Store{
-		Copier:                   scheme,
 		NewFunc:                  func() runtime.Object { return &clusterregistry.Cluster{} },
 		NewListFunc:              func() runtime.Object { return &clusterregistry.ClusterList{} },
 		PredicateFunc:            cluster.MatchCluster,

--- a/pkg/registry/cluster/registry.go
+++ b/pkg/registry/cluster/registry.go
@@ -23,7 +23,6 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/cluster-registry/pkg/apis/clusterregistry"
-	"k8s.io/cluster-registry/pkg/apis/clusterregistry/install"
 )
 
 // Registry is an interface implemented by things that know how to store Cluster objects.
@@ -73,7 +72,7 @@ func (s *storage) CreateCluster(ctx genericapirequest.Context, cluster *clusterr
 }
 
 func (s *storage) UpdateCluster(ctx genericapirequest.Context, cluster *clusterregistry.Cluster) error {
-	_, _, err := s.Update(ctx, cluster.Name, rest.DefaultUpdatedObjectInfo(cluster, install.Scheme))
+	_, _, err := s.Update(ctx, cluster.Name, rest.DefaultUpdatedObjectInfo(cluster))
 	return err
 }
 


### PR DESCRIPTION
This is a first step towards checked-in vendored dependencies.

- Update the Go rules to use the same version as used by `k/k`
- Update the `k/` dependencies to post-1.8 versions.

The versions used here were generally those pulled by the `dep` tool, which I have been using for vendoring. A future PR will replace the `WORKSPACE` dependencies with a vendor tree.

/assign @madhusudancs, @pmorie 
cc @font 