### PR TITLE
Add issue and PR templates to the cluster registry.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->
+
+/sig multicluster

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->
+
+/sig multicluster


### PR DESCRIPTION
We can add more content to these later, but for now this is a low-tech way to make sure that issues and PRs are (usually) labelled `sig/multicluster`.

/cc @madhusudancs