### PR TITLE
Cluster Registry support for delegated auth

### DIFF
--- a/pkg/clusterregistry/testing/testserver.go
+++ b/pkg/clusterregistry/testing/testserver.go
@@ -102,6 +102,7 @@ func startTestServer(t *testing.T) (result *restclient.Config, tearDownForCaller
 	s.SecureServing.ServerCert.CertDirectory = tmpDir
 	s.Etcd.StorageConfig = *storageConfig
 	s.Etcd.DefaultStorageMediaType = "application/json"
+	s.StandaloneMode = true
 
 	t.Logf("Starting cluster registry...")
 	server, err := clusterregistry.CreateServer(s)

--- a/pkg/crinit/standalone/standalone.go
+++ b/pkg/crinit/standalone/standalone.go
@@ -145,8 +145,8 @@ func Run(opts *standaloneClusterRegistryOptions, cmdOut io.Writer,
 		return err
 	}
 
-	err = opts.CreateAPIServer(cmdOut, hostClientset, opts.apiServerEnableHTTPBasicAuth,
-		opts.apiServerEnableTokenAuth, ips, pvc)
+	err = opts.CreateAPIServer(cmdOut, hostClientset, true, opts.apiServerEnableHTTPBasicAuth,
+		opts.apiServerEnableTokenAuth, ips, pvc, "default")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

This is now ready to test.

Currently hitting re-defined flags being added due to standalone and delegated sharing similar flags e.g. `authentication-token-webhook-cache-ttl`, `client-ca-file`, etc. Need to either create a common interface for both with a common option flag structure they can both share, create different subcommands, or something else. Problem with a common interface and common option flag structure is that for delegated we rely on the `apiserver` API which we don't own, whereas for standalone we have our own implementation. Also see #69 for more details.

Fix for #8 when this PR is complete.

/sig multicluster
