### PR TITLE
Add examples for the cluster registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /bazel-*
+examples/samplecontainer/contents/clusterregistry
+examples/samplecontainer/contents/slackcontroller

--- a/examples/samplecontainer/Dockerfile
+++ b/examples/samplecontainer/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:latest
+
+ARG ETCD_VERSION=3.2.9
+ARG KUBE_VERSION=1.8.3
+
+RUN mkdir -p /sample
+
+WORKDIR /sample
+
+RUN apt-get -qq update && apt-get -y install curl iproute2
+RUN curl -Lo kubernetes.tar.gz https://dl.k8s.io/v$KUBE_VERSION/kubernetes-server-linux-amd64.tar.gz
+RUN curl -Lo etcd.tar.gz https://github.com/coreos/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-amd64.tar.gz
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl
+
+RUN chmod +x kubectl
+RUN tar xzf etcd.tar.gz
+RUN tar xzf kubernetes.tar.gz
+
+ADD ["contents/*", "/sample/"]
+
+ENTRYPOINT ["./run.sh"]
+
+EXPOSE 8080

--- a/examples/samplecontainer/README.md
+++ b/examples/samplecontainer/README.md
@@ -1,0 +1,36 @@
+# Sample container
+
+This directory contains a `Dockerfile` that describes an image that runs a
+`clusterregistry` aggregated to a standalone `kube-apiserver`, both of which
+store data in an `etcd` instance. It also runs a `slackcontroller` that watches
+for cluster addition and removal. The image does not set up any security
+features, and should not serve as a model for a production deployment, but as an
+example of all of the necessary component pieces working together in the
+simplest possible fashion.
+
+To build, from this directory, run:
+
+```sh
+bazel build //cmd/clusterregistry //examples/slackcontroller
+cp "$(bazel info bazel-bin)/cmd/clusterregistry/clusterregistry" \
+  "$(bazel info bazel-bin)/examples/slackcontroller/slackcontroller" \
+  ./contents
+docker build . -t crexample:latest
+```
+
+To run:
+
+```sh
+docker run -p 8080 crexample:latest <slack_incoming_webhook_url>
+```
+
+This will print out several messages as the various components being run are
+started, but it should stabilize after several seconds and only be printing
+messages about the `OpenAPI AggregationController` every minute. Run `docker ps`
+to figure out the port that Docker has exposed, and access the API server
+running in the container at `localhost:<port>`. For example,
+
+```sh
+$ kubectl get clusters -s localhost:<port>
+No resources found
+```

--- a/examples/samplecontainer/cluster-two.yaml
+++ b/examples/samplecontainer/cluster-two.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: clusterregistry.k8s.io/v1alpha1
+metadata:
+  name: also-my-cluster
+  labels:
+    foo: bar
+spec:
+  kubernetesApiEndpoints:
+    serverEndpoints:
+      - clientCidr: "0.0.0.0"
+        serverAddress: "127.0.0.1"

--- a/examples/samplecontainer/cluster.yaml
+++ b/examples/samplecontainer/cluster.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: clusterregistry.k8s.io/v1alpha1
+metadata:
+  name: my-cluster
+  labels:
+    foo: bar
+spec:
+  kubernetesApiEndpoints:
+    serverEndpoints:
+      - clientCidr: "0.0.0.0"
+        serverAddress: "127.0.0.1"

--- a/examples/samplecontainer/contents/config
+++ b/examples/samplecontainer/contents/config
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: http://localhost:8080
+  name: cr
+contexts:
+- context:
+    cluster: cr
+    user: cr
+  name: cr
+current-context: cr
+kind: Config
+preferences: {}
+users:
+- name: cr
+  user:
+    username: cr@example.org

--- a/examples/samplecontainer/contents/cr-apiservice.yaml
+++ b/examples/samplecontainer/contents/cr-apiservice.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.clusterregistry.k8s.io
+spec:
+  insecureSkipTLSVerify: true
+  group: clusterregistry.k8s.io
+  groupPriorityMinimum: 100
+  version: v1alpha1
+  versionPriority: 100
+  service:
+    name: cr-service
+    namespace: default

--- a/examples/samplecontainer/contents/cr-service.yaml
+++ b/examples/samplecontainer/contents/cr-service.yaml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: cr-service
+spec:
+  type: ExternalName
+  externalName: "127.0.0.1"
+  ports:
+  - port: 443
+    protocol: TCP

--- a/examples/samplecontainer/contents/run.sh
+++ b/examples/samplecontainer/contents/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+etcd-v3.2.9-linux-amd64/etcd &
+
+kubernetes/server/bin/kube-apiserver \
+  --insecure-bind-address 0.0.0.0 \
+  --etcd-servers http://127.0.0.1:2379 \
+  --service-cluster-ip-range=10.10.0.0/14 &
+
+./clusterregistry \
+  --secure-port 443 \
+  --etcd-servers http://127.0.0.1:2379 &
+
+while [[ $(curl http://localhost:8080/healthz 2>/dev/null) != "ok" ]]; do
+  sleep 1
+done
+
+./kubectl create -f cr-service.yaml -s http://localhost:8080
+./kubectl create -f cr-apiservice.yaml -s http://localhost:8080
+./slackcontroller -kubeconfig ./config -slack-url "$@"

--- a/examples/slackcontroller/BUILD.bazel
+++ b/examples/slackcontroller/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "main.go",
+        "slackcontroller.go",
+    ],
+    importpath = "k8s.io/cluster-registry/examples/slackcontroller",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/client/clientset_generated/clientset:go_default_library",
+        "//pkg/client/clientset_generated/clientset/scheme:go_default_library",
+        "//pkg/client/informers_generated/externalversions:go_default_library",
+        "//pkg/client/listers_generated/clusterregistry/v1alpha1:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "slackcontroller",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/cluster-registry/examples/slackcontroller",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/examples/slackcontroller/README.md
+++ b/examples/slackcontroller/README.md
@@ -1,0 +1,15 @@
+# SlackController
+
+A sample controller that demonstrates how to write a controller that targets the
+cluster registry. This controller will post messages to a Slack channel when a
+cluster is added to or removed from the registry.
+
+## Quickstart
+
+1.  Set up a cluster registry. You can use
+    [crinit](/docs/userguide.md#deploying-a-cluster-registry) to do so.
+1.  Run `bazel build //examples/slackcontroller` to build the controller.
+1.  Create a [Slack incoming webhook](https://api.slack.com/incoming-webhooks)
+    and get its URL to pass via the `-slack-url` flag on `slackcontroller`.
+1.  Deploy the cluster registry into a cluster, making sure you pass the
+    incoming webhook URL to its `-slack-url` flag.

--- a/examples/slackcontroller/main.go
+++ b/examples/slackcontroller/main.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/cluster-registry/pkg/client/clientset_generated/clientset"
+
+	informers "k8s.io/cluster-registry/pkg/client/informers_generated/externalversions"
+)
+
+var (
+	masterURL  string
+	kubeconfig string
+	slackURL   string
+)
+
+// setUpSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
+// which is closed on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func setUpSignalHandler() (stopCh <-chan struct{}) {
+	stop := make(chan struct{})
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		close(stop)
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return stop
+}
+
+func main() {
+	flag.Parse()
+
+	stopCh := setUpSignalHandler()
+
+	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+	if err != nil {
+		glog.Fatalf("Error building kubeconfig: %s", err.Error())
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		glog.Fatalf("Error building kubernetes clientset: %s", err.Error())
+	}
+	clusterClient, err := clientset.NewForConfig(cfg)
+	if err != nil {
+		glog.Fatalf("Error building cluster clientset: %s", err.Error())
+	}
+
+	clusterInformerFactory := informers.NewSharedInformerFactory(clusterClient, time.Second*30)
+
+	controller := NewSlackController(kubeClient, clusterClient, clusterInformerFactory, slackURL)
+
+	go clusterInformerFactory.Start(stopCh)
+
+	if err = controller.Run(2, stopCh); err != nil {
+		glog.Fatalf("Error running controller: %s", err.Error())
+	}
+}
+
+func init() {
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value provided in the default context in kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&slackURL, "slack-url", "", "The URL of a Slack Incoming Webhook to which messages will be posted. Must be non-empty, or this controller will be ineffectual. See https://api.slack.com/incoming-webhooks.")
+}

--- a/examples/slackcontroller/slackcontroller.go
+++ b/examples/slackcontroller/slackcontroller.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	"k8s.io/cluster-registry/pkg/client/clientset_generated/clientset"
+	clusterregistryscheme "k8s.io/cluster-registry/pkg/client/clientset_generated/clientset/scheme"
+	informers "k8s.io/cluster-registry/pkg/client/informers_generated/externalversions"
+	listers "k8s.io/cluster-registry/pkg/client/listers_generated/clusterregistry/v1alpha1"
+)
+
+const controllerAgentName = "clusterregistry-controller"
+
+const (
+	// SuccessSynced is used as part of the Event 'reason' when a Cluster is synced
+	SuccessSynced = "Synced"
+
+	// MessageResourceSynced is the message used for an Event fired when a Cluster
+	// is synced successfully
+	MessageResourceSynced = "Cluster synced successfully"
+)
+
+// Controller is the controller implementation for Cluster resources
+type Controller struct {
+	// kubeclientset is a standard kubernetes clientset
+	kubeclientset kubernetes.Interface
+	// clusterregistryclientset is a clientset for our own API group
+	clusterregistryclientset clientset.Interface
+
+	clusterLister  listers.ClusterLister
+	clustersSynced cache.InformerSynced
+
+	// workqueue is a rate limited work queue. This is used to queue work to be
+	// processed instead of performing it as soon as a change happens. This
+	// means we can ensure we only process a fixed amount of resources at a
+	// time, and makes it easy to ensure we are never processing the same item
+	// simultaneously in two different workers.
+	workqueue workqueue.RateLimitingInterface
+
+	// recorder is an event recorder for recording Event resources to the
+	// Kubernetes API.
+	recorder record.EventRecorder
+
+	// slackURL is the URL of the Slack Incoming Webhook to which to post
+	// notifications about cluster changes.
+	slackURL string
+}
+
+// NewSlackController returns a new clusterregistry controller
+func NewSlackController(
+	kubeclientset kubernetes.Interface,
+	clusterregistryclientset clientset.Interface,
+	clusterregistryInformerFactory informers.SharedInformerFactory,
+	slackURL string) *Controller {
+
+	// obtain references to shared index informers for the Cluster type.
+	clusterInformer := clusterregistryInformerFactory.Clusterregistry().V1alpha1().Clusters()
+
+	// Create event broadcaster
+	// Add clusterregistry-controller types to the default Kubernetes Scheme so Events can be
+	// logged for clusterregistry-controller types.
+	clusterregistryscheme.AddToScheme(scheme.Scheme)
+	glog.V(4).Info("Creating event broadcaster")
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
+
+	controller := &Controller{
+		kubeclientset:            kubeclientset,
+		clusterregistryclientset: clusterregistryclientset,
+		clusterLister:            clusterInformer.Lister(),
+		clustersSynced:           clusterInformer.Informer().HasSynced,
+		workqueue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Clusters"),
+		recorder:                 recorder,
+		slackURL:                 slackURL,
+	}
+
+	glog.Info("Setting up event handlers")
+	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.enqueueCluster,
+		DeleteFunc: controller.enqueueCluster,
+	})
+
+	return controller
+}
+
+// Run will set up the event handlers for types we are interested in, as well
+// as syncing informer caches and starting workers. It will block until stopCh
+// is closed, at which point it will shutdown the workqueue and wait for
+// workers to finish processing their current work items.
+func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
+	defer runtime.HandleCrash()
+	defer c.workqueue.ShutDown()
+
+	// Start the informer factories to begin populating the informer caches
+	glog.Info("Starting Cluster controller")
+
+	// Wait for the caches to be synced before starting workers
+	glog.Info("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(stopCh, c.clustersSynced); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	glog.Info("Starting workers")
+	// Launch two workers to process Cluster resources
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	glog.Info("Started workers")
+	<-stopCh
+	glog.Info("Shutting down workers")
+
+	return nil
+}
+
+// runWorker is a long-running function that will continually call the
+// processNextWorkItem function in order to read and process a message on the
+// workqueue.
+func (c *Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+// processNextWorkItem will read a single work item off the workqueue and
+// attempt to process it, by calling the syncHandler.
+func (c *Controller) processNextWorkItem() bool {
+	obj, shutdown := c.workqueue.Get()
+
+	if shutdown {
+		return false
+	}
+
+	// We wrap this block in a func so we can defer c.workqueue.Done.
+	err := func(obj interface{}) error {
+		// We call Done here so the workqueue knows we have finished
+		// processing this item. We also must remember to call Forget if we
+		// do not want this work item being re-queued. For example, we do
+		// not call Forget if a transient error occurs, instead the item is
+		// put back on the workqueue and attempted again after a back-off
+		// period.
+		defer c.workqueue.Done(obj)
+		var key string
+		var ok bool
+		// We expect strings to come off the workqueue. These are of the
+		// form namespace/name. We do this as the delayed nature of the
+		// workqueue means the items in the informer cache may actually be
+		// more up to date that when the item was initially put onto the
+		// workqueue.
+		if key, ok = obj.(string); !ok {
+			// As the item in the workqueue is actually invalid, we call
+			// Forget here else we'd go into a loop of attempting to
+			// process a work item that is invalid.
+			c.workqueue.Forget(obj)
+			runtime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+		// Run the syncHandler, passing it the namespace/name string of the
+		// cluster resource to be synced.
+		if err := c.syncHandler(key); err != nil {
+			return fmt.Errorf("error syncing '%s': %s", key, err.Error())
+		}
+		// Finally, if no error occurs we Forget this item so it does not
+		// get queued again until another change happens.
+		c.workqueue.Forget(obj)
+		glog.Infof("Successfully synced '%s'", key)
+		return nil
+	}(obj)
+
+	if err != nil {
+		runtime.HandleError(err)
+		return true
+	}
+
+	return true
+}
+
+// syncHandler sends Slack notifications when the cluster is updated.
+func (c *Controller) syncHandler(key string) error {
+	// Convert the namespace/name string into a distinct namespace and name
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+
+	bodyFormatString := "Cluster %s was added."
+	// Get the Cluster resource with this name
+	cluster, err := c.clusterLister.Get(name)
+	if err != nil {
+		// The Cluster resource may have been deleted, in which case we
+		// post a removal message.
+		if errors.IsNotFound(err) {
+			bodyFormatString = "Cluster %s was removed."
+		} else {
+			return err
+		}
+	}
+
+	body := strings.NewReader(fmt.Sprintf("{ 'text':'%s'}", fmt.Sprintf(bodyFormatString, name)))
+	client := &http.Client{}
+	resp, err := client.Post(c.slackURL, "application/json", body)
+	if err != nil {
+		return err
+	}
+	glog.V(4).Infof("%#v", resp)
+
+	if cluster != nil {
+		c.recorder.Event(cluster, corev1.EventTypeNormal, SuccessSynced, MessageResourceSynced)
+	}
+	return nil
+}
+
+// enqueueCluster takes a Cluster resource and converts it into a namespace/name
+// string which is then put onto the work queue. This method should *not* be
+// passed resources of any type other than Cluster.
+func (c *Controller) enqueueCluster(obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	c.workqueue.AddRateLimited(key)
+}


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

These are a bit messy still, but they demonstrate a simple controller and how the cluster registry API server runs. We can iterate.

Addresses #108.