### PR TITLE
Stamp bazel-built binaries with version informaton

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+# Include git version info
+build --workspace_status_command hack/print-workspace-status.sh

--- a/cmd/clusterregistry/BUILD.bazel
+++ b/cmd/clusterregistry/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build", "docker_push")
+load("//pkg/version:def.bzl", "version_x_defs")
 
 docker_build(
     name = "clusterregistry-image",
@@ -24,6 +25,7 @@ go_library(
     deps = [
         "//pkg/clusterregistry:go_default_library",
         "//pkg/clusterregistry/options:go_default_library",
+        "//pkg/version:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
@@ -36,4 +38,5 @@ go_binary(
     importpath = "k8s.io/cluster-registry/cmd/clusterregistry",
     library = ":go_default_library",
     visibility = ["//visibility:public"],
+    x_defs = version_x_defs(),
 )

--- a/cmd/clusterregistry/clusterregistry.go
+++ b/cmd/clusterregistry/clusterregistry.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/cluster-registry/pkg/clusterregistry"
 	"k8s.io/cluster-registry/pkg/clusterregistry/options"
+	"k8s.io/cluster-registry/pkg/version"
 
 	"github.com/spf13/pflag"
 )
@@ -39,8 +40,16 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	s := options.NewServerRunOptions()
+
 	s.AddFlags(pflag.CommandLine)
+	versionFlag := pflag.CommandLine.Bool("version", false, "Prints out version information and exits.")
+
 	flag.InitFlags()
+
+	if *versionFlag {
+		fmt.Printf("%#v\n", version.Get())
+		return
+	}
 
 	if err := clusterregistry.Run(s, wait.NeverStop); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/cmd/crinit/BUILD.bazel
+++ b/cmd/crinit/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//pkg/version:def.bzl", "version_x_defs")
 
 go_library(
     name = "go_default_library",
@@ -17,4 +18,5 @@ go_binary(
     importpath = "k8s.io/cluster-registry/cmd/crinit",
     library = ":go_default_library",
     visibility = ["//visibility:public"],
+    x_defs = version_x_defs(),
 )

--- a/docs/development.md
+++ b/docs/development.md
@@ -116,6 +116,30 @@ generated clients and other generated files.
 1.  Add the generated files to your PR, preferably in a separate, generated-only
     commit so that they are easier to review.
 
+## Release and build versioning
+
+[`pkg/version`](/pkg/version) contains infrastructure for generating version
+information for builds of the cluster registry. Version info is provided to the
+go_binary build rules in the `x_refs` parameter by
+[`pkg/version/def.bzl`](/pkg/version/def.bzl). The information is derived from
+the Git repository state and build state by
+[`hack/print-workspace-status.sh`](/hack/print-workspace-status.sh). This script
+is run on each `bazel build` invocation by way of a [`.bazelrc`](\.bazelrc) file
+in the repository's root directory. There is some more info about bazel build
+stamping
+[here](https://www.kchodorow.com/blog/2017/03/27/stamping-your-builds/). Builds
+done without `bazel` will get default version information.
+
+### Tagging
+
+The version information is derived largely from annotated git tags. Tags for a
+release should be of the form `vX.Y.Z`. Release candidates should be of the form
+`vX.Y.Z-rc.N`, where `N` starts at 0 and is incremented with each release
+candidate.
+
+This tagging scheme is subject to change as the cluster registry moves through
+alpha and beta.
+
 ## Nightly releases
 
 The cluster registry has a script, [`hack/release.sh`](../hack/release.sh), that

--- a/hack/print-workspace-status.sh
+++ b/hack/print-workspace-status.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This command is used by bazel as the workspace_status_command
+# to implement build stamping with git information. It pulls information
+# from tags named like vX.Y.Z with an optional postfix, e.g., v1.2.3-alpha.
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+GIT=(git --work-tree "${REPO_ROOT}")
+
+if GIT_COMMIT=$("${GIT[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
+  # Check if the tree is dirty. Default to dirty
+  GIT_TREE_STATE="dirty"
+  if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+    GIT_TREE_STATE="clean"
+  fi
+
+  # Use git describe to find the version based on annotated tags.
+  if GIT_VERSION=$("${GIT[@]}" describe --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null); then
+    # This translates the "git describe" to an actual semver.org
+    # compatible semantic version that looks something like this:
+    #   v1.1.0-alpha.0.6+84c76d1142ea4d
+    DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
+    if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+      # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+      GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
+    elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+      # We have distance to base tag (v1.1.0-1-gCommitHash)
+      GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
+    fi
+    if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
+      # git describe --dirty only considers changes to existing files, but
+      # that is problematic since new untracked .go files affect the build,
+      # so use our idea of "dirty" from git status instead.
+      GIT_VERSION+="-dirty"
+    fi
+  fi
+fi
+
+# Set default version information if there are no tags to read.
+if [[ -z ${GIT_VERSION-} ]]; then
+  GIT_VERSION="0.0"
+fi
+
+# Prefix with STABLE_ so that these values are saved to stable-status.txt
+# instead of volatile-status.txt.
+# Stamped rules will be retriggered by changes to stable-status.txt, but not by
+# changes to volatile-status.txt.
+# IMPORTANT: the camelCase vars should match the list in pkg/version/def.bzl.
+cat <<EOF
+STABLE_BUILD_GIT_COMMIT ${GIT_COMMIT}
+STABLE_BUILD_SCM_STATUS ${GIT_TREE_STATE}
+STABLE_BUILD_SCM_REVISION ${GIT_VERSION}
+buildDate $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+gitCommit ${GIT_COMMIT}
+gitTreeState ${GIT_TREE_STATE}
+semanticVersion ${GIT_VERSION}
+EOF

--- a/pkg/crinit/BUILD.bazel
+++ b/pkg/crinit/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/crinit/aggregated:go_default_library",
         "//pkg/crinit/standalone:go_default_library",
+        "//pkg/version:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",

--- a/pkg/crinit/crinit.go
+++ b/pkg/crinit/crinit.go
@@ -18,12 +18,14 @@ package crinit
 
 import (
 	"flag"
+	"fmt"
 	"io"
 
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/cluster-registry/pkg/crinit/aggregated"
 	"k8s.io/cluster-registry/pkg/crinit/standalone"
+	"k8s.io/cluster-registry/pkg/version"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -46,8 +48,17 @@ func NewClusterregistryCommand(out io.Writer, defaultServerImage, defaultEtcdIma
 	// Warn for other flags that contain underscores.
 	rootCmd.SetGlobalNormalizationFunc(apiserverflag.WarnWordSepNormalizeFunc)
 
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("%#v", version.Get())
+		},
+	}
+
 	rootCmd.AddCommand(standalone.NewCmdStandalone(out, clientcmd.NewDefaultPathOptions(), defaultServerImage, defaultEtcdImage))
 	rootCmd.AddCommand(aggregated.NewCmdAggregated(out, clientcmd.NewDefaultPathOptions(), defaultServerImage, defaultEtcdImage))
+	rootCmd.AddCommand(versionCmd)
 
 	return rootCmd
 }

--- a/pkg/crinit/standalone/BUILD.bazel
+++ b/pkg/crinit/standalone/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
-        "//vendor/k8s.io/client-go/util/cert/triple:go_default_library",
     ],
 )
 

--- a/pkg/version/BUILD.bazel
+++ b/pkg/version/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "base.go",
+        "version.go",
+    ],
+    importpath = "k8s.io/cluster-registry/pkg/version",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/version:go_default_library"],
+)

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via bazel workspace stamping. It is not meant to be at all
+// accurate, only to prevent build failures.
+var (
+	// semantic version, derived by build scripts (see
+	// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md
+	// for a detailed discussion of this field)
+	semanticVersion = "v0.0.0"
+	gitCommit       = "unknown"
+	gitTreeState    = "dirty"
+
+	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)

--- a/pkg/version/def.bzl
+++ b/pkg/version/def.bzl
@@ -1,0 +1,17 @@
+# Provides stamped variables from the Bazel workspace status. Use with the
+# x_defs field of a go_binary rule.
+def version_x_defs():
+  stamp_pkgs = ["k8s.io/cluster-registry/pkg/version"]
+  # It should match the list of vars set in hack/print-workspace-status.sh.
+  stamp_vars = [
+      "buildDate",
+      "gitCommit",
+      "gitTreeState",
+      "semanticVersion",
+  ]
+  # Generate the cross-product.
+  x_defs = {}
+  for pkg in stamp_pkgs:
+    for var in stamp_vars:
+      x_defs["%s.%s" % (pkg, var)] = "{%s}" % var
+  return x_defs

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+)
+
+// Get returns the overall codebase version. It's used for detecting what code
+// a binary was built from.
+func Get() apimachineryversion.Info {
+	return apimachineryversion.Info{
+		GitVersion:   semanticVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

We can determine a better versioning/tagging strategy later. This is mostly pulled from k/k, with some simplifications. At the least, it gives us a way to track what versions of the tools people are using, which is a big win.

/cc @pmorie @madhusudancs @font