### PR TITLE
Add init subcommands to the aggregated and standalone crinit commands.

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -32,7 +32,7 @@ tar xzf clusterregistry-$PACKAGE.tar.gz
 You can deploy the cluster registry as a standalone API server like so:
 
 ```sh
-./crinit standalone <cluster_registry_instance_name> --host-cluster-context=<your_cluster_context>
+./crinit standalone init <cluster_registry_instance_name> --host-cluster-context=<your_cluster_context>
 ```
 
 where `cluster_registry_instance_name` is the name you want to give this cluster
@@ -56,7 +56,7 @@ $
 You can deploy the cluster registry as an aggregated API server like so:
 
 ```sh
-./crinit aggregated <cluster_registry_context> --host-cluster-context=<your_cluster_context>
+./crinit aggregated init <cluster_registry_context> --host-cluster-context=<your_cluster_context>
 ```
 
 where `your_cluster_context` is a context entry in your kubeconfig file

--- a/pkg/crinit/aggregated/aggregated.go
+++ b/pkg/crinit/aggregated/aggregated.go
@@ -42,17 +42,17 @@ import (
 )
 
 var (
-	longCommandDescription = `
-	Aggregated initializes an aggregated cluster registry.
+	longInitCommandDescription = `
+	Init initializes an aggregated cluster registry.
 
 	The aggregated cluster registry is hosted inside a Kubernetes
 	cluster and registers its API with the Kubernetes API aggregator.
 	The host cluster must be specified using the --host-cluster-context flag.`
-	commandExample = `
+	initCommandExample = `
 	# Initialize an aggregated cluster registry named foo
 	# in the host cluster whose local kubeconfig
 	# context is bar.
-	crinit aggregated foo --host-cluster-context=bar`
+	crinit aggregated init foo --host-cluster-context=bar`
 
 	// Set priorities for our API in the APIService object.
 	apiServiceGroupPriorityMinimum int32 = 10000
@@ -113,10 +113,16 @@ func NewCmdAggregated(cmdOut io.Writer, pathOptions *clientcmd.PathOptions, defa
 	opts := &aggregatedClusterRegistryOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "aggregated CLUSTER_REGISTRY_NAME --host-cluster-context=HOST_CONTEXT",
-		Short:   "Initializes an aggregated cluster registry",
-		Long:    longCommandDescription,
-		Example: commandExample,
+		Use:   "aggregated",
+		Short: "Subcommands to manage an aggregated cluster registry",
+		Long:  "Commands used to manage an aggregated cluster registry. That is, a cluster registry that is aggregated with another Kubernetes API server.",
+	}
+
+	initCmd := &cobra.Command{
+		Use:     "init CLUSTER_REGISTRY_NAME --host-cluster-context=HOST_CONTEXT",
+		Short:   "Initialize an aggregated cluster registry.",
+		Long:    longInitCommandDescription,
+		Example: initCommandExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.SetName(args)
 			if err != nil {
@@ -152,9 +158,11 @@ func NewCmdAggregated(cmdOut io.Writer, pathOptions *clientcmd.PathOptions, defa
 		},
 	}
 
-	flags := cmd.Flags()
+	flags := initCmd.Flags()
 	opts.BindCommon(flags, defaultServerImage, defaultEtcdImage)
 	opts.Bind(flags)
+
+	cmd.AddCommand(initCmd)
 
 	return cmd
 }

--- a/pkg/crinit/crinit.go
+++ b/pkg/crinit/crinit.go
@@ -50,13 +50,19 @@ func NewClusterregistryCommand(out io.Writer, defaultServerImage, defaultEtcdIma
 	// Warn for other flags that contain underscores.
 	rootCmd.SetGlobalNormalizationFunc(apiserverflag.WarnWordSepNormalizeFunc)
 
+	var shortVersion bool
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Prints the version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("%#v", version.Get())
+			if shortVersion {
+				fmt.Printf("%s\n", version.Get().GitVersion)
+			} else {
+				fmt.Printf("%#v\n", version.Get())
+			}
 		},
 	}
+	versionCmd.Flags().BoolVar(&shortVersion, "short", false, "Print just the version number.")
 
 	rootCmd.AddCommand(standalone.NewCmdStandalone(out, clientcmd.NewDefaultPathOptions(), defaultServerImage, defaultEtcdImage))
 	rootCmd.AddCommand(aggregated.NewCmdAggregated(out, clientcmd.NewDefaultPathOptions(), defaultServerImage, defaultEtcdImage))

--- a/pkg/crinit/standalone/standalone.go
+++ b/pkg/crinit/standalone/standalone.go
@@ -33,18 +33,18 @@ import (
 )
 
 var (
-	longCommandDescription = `
-	Standalone initializes a standalone cluster registry.
+	longInitCommandDescription = `
+	Init initializes a standalone cluster registry.
 
 	The standalone cluster registry is hosted inside a Kubernetes
 	cluster but handles its own authentication and authorization.
 	The host cluster must be specified using the
         --host-cluster-context flag.`
-	commandExample = `
+	initCommandExample = `
 	# Initialize a standalone cluster registry named foo
 	# in the host cluster whose local kubeconfig
 	# context is bar.
-	crinit standalone foo --host-cluster-context=bar`
+	crinit standalone init foo --host-cluster-context=bar`
 )
 
 type standaloneClusterRegistryOptions struct {
@@ -70,10 +70,16 @@ func NewCmdStandalone(cmdOut io.Writer, pathOptions *clientcmd.PathOptions, defa
 	opts := &standaloneClusterRegistryOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "standalone CLUSTER_REGISTRY_NAME --host-cluster-context=HOST_CONTEXT",
+		Use:   "standalone",
+		Short: "Subcommands to manage a standalone cluster registry",
+		Long:  "Commands used to manage a standalone cluster registry. That is, a cluster registry that is not aggregated with another Kubernetes API server.",
+	}
+
+	initCmd := &cobra.Command{
+		Use:     "init CLUSTER_REGISTRY_NAME --host-cluster-context=HOST_CONTEXT",
 		Short:   "Initialize a standalone cluster registry",
-		Long:    longCommandDescription,
-		Example: commandExample,
+		Long:    longInitCommandDescription,
+		Example: initCommandExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.SetName(args)
 			if err != nil {
@@ -105,10 +111,11 @@ func NewCmdStandalone(cmdOut io.Writer, pathOptions *clientcmd.PathOptions, defa
 		},
 	}
 
-	flags := cmd.Flags()
+	flags := initCmd.Flags()
 	opts.BindCommon(flags, defaultServerImage, defaultEtcdImage)
 	opts.Bind(flags)
 
+	cmd.AddCommand(initCmd)
 	return cmd
 }
 


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

Also adds a `--short` flag for the version.

/cc @font @madhusudancs @pmorie 
