### PR TITLE
Update the release script to support versioned releases.

### DIFF
--- a/cmd/clusterregistry/BUILD.bazel
+++ b/cmd/clusterregistry/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build", "docker_push")
 load("//pkg/version:def.bzl", "version_x_defs")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 docker_build(
     name = "clusterregistry-image",
@@ -15,6 +16,12 @@ docker_push(
     registry = "gcr.io",
     repository = "$(repository)",
     tag = "dev",
+)
+
+pkg_tar(
+    name = "clusterregistry-server",
+    srcs = [":clusterregistry"],
+    extension = "tar.gz",
 )
 
 go_library(

--- a/cmd/crinit/BUILD.bazel
+++ b/cmd/crinit/BUILD.bazel
@@ -1,5 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//pkg/version:def.bzl", "version_x_defs")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "clusterregistry-client",
+    srcs = [":crinit"],
+    extension = "tar.gz",
+)
 
 go_library(
     name = "go_default_library",


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

Also moves to using `BUILD` rules to create tarballs, to simplify the script a bit.

/cc @font @madhusudancs @pmorie 

# Notes
- changes the layout of the GCR repo, removing the `nightly` subpath. It seems fine to have all images in one directory, since they are all tagged
- there is no hard link between repo tags and the version passed to the release script. This should be fixed later with automation