### PR TITLE
Update Gopkg.lock: the inputs-digest was out-of-date

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -460,6 +460,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0f2a234c15bb9e57f1e5c0ea935d6c53762ceed319141169cb995c7b5a7d4dfe"
+  inputs-digest = "0e112d5f4ff8e8210b6c0f8b2cfbd4222804fc13cb43f666f2d963f1a690873c"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

/cc @font @pmorie @madhusudancs 