### PR TITLE
Implement standalone webhook authoritzation.

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -148,3 +148,19 @@ and use the client library directly from your Go code.
 
 There is an OpenAPI spec file provided [here](/api/swagger.json). You can use
 it to generate client libraries in a language of your choice.
+
+## Troubleshooting
+
+### Multi-Attach error
+
+If you are updating the cluster registry deployment by hand, you may run into
+errors like the following:
+
+```
+Multi-Attach error for volume "vol" Volume is already exclusively attached to one node and can't be attached to another
+```
+
+This is because the new `clusterregistry` `Pod` will not be able to claim the
+persistent volume if it is started on a different node than the existing `Pod`.
+A simple fix is to change the `deployement.spec.strategy.type` to `Recreate`.
+There are more details in https://github.com/kubernetes/kubernetes/issues/48968.

--- a/examples/webhook-authz/README.md
+++ b/examples/webhook-authz/README.md
@@ -1,0 +1,107 @@
+# Example Webhook authorizer
+
+This directory contains the scaffolding necessary to use a webhook authorizer
+with the standalone cluster registry. It is not meant to be used with the
+aggregated cluster registry.
+
+NOTE: this example is not meant for production use! Do not deploy this into a
+production environment.
+
+## Usage
+
+1.  `cd` into this directory.
+
+2.  Deploy a standalone cluster registry. You can use
+    [crinit](https://github.com/kubernetes/cluster-registry/blob/master/docs/userguide.md#standalone).
+
+3.  Create a self-signed SSL cert for the cluster registry webhook authorizer
+    (or skip this step and use an existing SSL cert).
+
+```sh
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes
+```
+
+4.  Create a ConfigMap that contains the files needed for the cluster registry
+    webhook authorizer. If you deployed your cluster registry into a namespace
+    other than `clusterregistry`, change the namespace below accordingly.
+
+```sh
+kubectl create configmap bitesize -n clusterregistry \
+  --from-file=./rules.hcl --from-file=./webhook-config.yaml \
+  --from-file=./key.pem --from-file=./cert.pem
+```
+
+5.  Create the webhook authorizer. Note that you may need to change the
+    namespace if you did not deploy the cluster registry into the
+    `clusterregistry` namespace.
+
+```sh
+kubectl apply -f ./authz.yaml -n clusterregistry
+```
+
+6.  Update the cluster registry deployment as follows.
+
+```yaml
+...
+      - command:
+        - ./clusterregistry
+        ... existing flags ...
+        - --authorization-always-allow=false
+        - --authorization-webhook=true
+        - --authorization-webhook-config-file=/etc/bitesize/webhook-config.yaml
+        - --authorization-webhook-cache-authorized-ttl=5m
+        - --authorization-webhook-cache-unauthorized-ttl=30s
+        volumeMounts:
+          ... existing volumeMounts ...
+          - name: bitesize
+            mountPath: /etc/bitesize
+          - name: ca-certificates
+            mountPath: /etc/ssl/certs
+...
+      volumes:
+      ... existing volumes ...
+      - name: bitesize
+        configMap:
+          name: bitesize
+      - name: ca-certificates
+        hostPath:
+          path: /etc/ssl/certs
+...
+```
+
+> NOTE: You may run into an issue recreating the Pod because the persistent disk
+> is already being used. Refer [here](/docs/userguide.md#multi-attach-error) for
+> more info.
+
+If everything is running properly, and you have admin credentials for this
+cluster in your kubeconfig file, you should be able to access clusters as the
+admin user:
+
+```sh
+$ kubectl get clusters --context <your_cluster_registry_context> --user <your_admin_user>
+No resources found
+```
+
+and list them as `testuser`:
+
+```sh
+$ kubectl get clusters --context <your_cluster_registry_context> --as testuser
+No resources found
+```
+
+but not access them as someone else:
+
+```sh
+$ kubectl get clusters --context <your_cluster_registry_context> --as bob
+Error from server (Forbidden): clusters.clusterregistry.k8s.io is forbidden: User "bob" cannot list clusters.clusterregistry.k8s.io at the cluster scope: Not allowed
+```
+
+or create/update them as `testuser`:
+
+```
+sh
+$ kubectl apply -f cluster.yaml --context <your_cluster_registry_context> --as testuser
+Error from server (Forbidden): error when applying patch:
+...
+... clusters.clusterregistry.k8s.io "my-cluster" is forbidden: User "testuser" cannot patch clusters.clusterregistry.k8s.io at the cluster scope: Not allowed
+```

--- a/examples/webhook-authz/authz.yaml
+++ b/examples/webhook-authz/authz.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: bitesize-authz-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bitesize-authz-webhook
+  template:
+    metadata:
+      labels:
+        app: bitesize-authz-webhook
+    spec:
+      containers:
+        - name: bitesize-authz-webhook
+          image: geribatai/bitesize-authz-webhook:0.0.7
+          ports:
+          - containerPort: 8080
+            name: https
+            protocol: TCP
+          volumeMounts:
+            - name: bitesize
+              mountPath: /etc/bitesize
+          env:
+            - name: RULES_CONFIG
+              value: /etc/bitesize/rules.hcl
+            - name: HTTPS_ENABLED
+              value: "true"
+            - name: SSL_CERT
+              value: /etc/bitesize/cert.pem
+            - name: SSL_KEY
+              value: /etc/bitesize/key.pem
+      volumes:
+        - name: bitesize
+          configMap:
+            name: bitesize
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bitesize-authz-webhook-service
+  labels:
+    name: bitesize-authz-webhook-service
+spec:
+  ports:
+    - port: 443
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: bitesize-authz-webhook
+  type: ClusterIP

--- a/examples/webhook-authz/rules.hcl
+++ b/examples/webhook-authz/rules.hcl
@@ -1,0 +1,14 @@
+# kube-system default user can access any namespace
+access "allow" {
+    username = "system:serviceaccount:kube-system:default"
+    verb = "(list|watch|get)"
+}
+
+access "allow" {
+    username = "admin"
+}
+
+access "allow" {
+    username = "testuser"
+    verb = "(list|watch|get)"
+}

--- a/examples/webhook-authz/webhook-config.yaml
+++ b/examples/webhook-authz/webhook-config.yaml
@@ -1,0 +1,16 @@
+clusters:
+  - name: bitesize-authz
+    cluster:
+      insecure-skip-tls-verify: true
+      server: https://bitesize-authz-webhook-service:443
+users:
+  - name: user
+    user:
+      client-certificate: /etc/bitesize/cert.pem
+      client-key: /etc/bitesize/key.pem
+current-context: webhook
+contexts:
+- context:
+    cluster: bitesize-authz
+    user: user
+  name: webhook

--- a/pkg/clusterregistry/options/BUILD.bazel
+++ b/pkg/clusterregistry/options/BUILD.bazel
@@ -22,5 +22,6 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
+        "//vendor/k8s.io/apiserver/plugin/pkg/authorizer/webhook:go_default_library",
     ],
 )

--- a/pkg/clusterregistry/options/authorization.go
+++ b/pkg/clusterregistry/options/authorization.go
@@ -17,32 +17,83 @@ limitations under the License.
 package options
 
 import (
+	"errors"
+	"time"
+
+	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/plugin/pkg/authorizer/webhook"
 )
 
 // StandaloneAuthorizerConfig configures an authorizer for the standalone
 // cluster registry.
 type StandaloneAuthorizerConfig struct {
+	// AlwaysAllow allows all requests that are validated by an authenticator full
+	// access to cluster registry resources. This overrides all other authorizers.
 	AlwaysAllow bool
+
+	// Webhook uses an external webhook to authorize requests.
+	Webhook bool
+
+	// WebhookConfigFile is the file that contains the webhook configuration in
+	// kubeconfig format.
+	WebhookConfigFile string
+
+	// WebhookCacheAuthorizedTTL is the length of time that a successful webhook
+	// authorization response will be cached.
+	WebhookCacheAuthorizedTTL time.Duration
+
+	// WebhookCacheUnauthorizedTTL is the length of time that an unsuccessful
+	// authorization response will be cached. You generally want more responsive,
+	// "deny, try again" flows.
+	WebhookCacheUnauthorizedTTL time.Duration
 }
 
+// New creates a new authorizer based on the receiver's configured values.
 func (s StandaloneAuthorizerConfig) New() (authorizer.Authorizer, error) {
 	if s.AlwaysAllow {
 		return authorizerfactory.NewAlwaysAllowAuthorizer(), nil
 	}
+	if s.Webhook {
+		if s.WebhookConfigFile == "" {
+			return nil, errors.New("webhook configuration file not provided")
+		}
+		return webhook.New(s.WebhookConfigFile, s.WebhookCacheAuthorizedTTL, s.WebhookCacheUnauthorizedTTL)
+	}
+	glog.Info("No authorizer specified; defaulting to AlwaysDeny")
 	return authorizerfactory.NewAlwaysDenyAuthorizer(), nil
 }
 
 // StandaloneAuthorizationOptions configure authorization in the cluster registry
 // when it is run as a standalone API server.
 type StandaloneAuthorizationOptions struct {
+	// AlwaysAllow allows all requests that are validated by an authenticator full
+	// access to cluster registry resources. This overrides all other authorizers.
 	AlwaysAllow bool
+
+	// Webhook uses an external webhook to authorize requests.
+	Webhook bool
+
+	// WebhookConfigFile is the file that contains the webhook configuration in
+	// kubeconfig format.
+	WebhookConfigFile string
+
+	// WebhookCacheAuthorizedTTL is the length of time that a successful webhook
+	// authorization response will be cached.
+	WebhookCacheAuthorizedTTL time.Duration
+
+	// WebhookCacheUnauthorizedTTL is the length of time that an unsuccessful
+	// authorization response will be cached. You generally want more responsive,
+	// "deny, try again" flows.
+	WebhookCacheUnauthorizedTTL time.Duration
 }
 
+// NewStandaloneAuthorizationOptions returns a default set of standalone
+// authorization options.
 func NewStandaloneAuthorizationOptions() *StandaloneAuthorizationOptions {
 	return &StandaloneAuthorizationOptions{AlwaysAllow: true}
 }
@@ -52,10 +103,30 @@ func (s *StandaloneAuthorizationOptions) Validate() []error {
 	return []error{}
 }
 
+// AddFlags add flags to configure the receiver's values to the provided
+// FlagSet.
 func (s *StandaloneAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
-	// TODO: Add a flag to set AlwaysAllow.
+	fs.BoolVar(&s.AlwaysAllow, "authorization-always-allow", s.AlwaysAllow,
+		"Whether to authorize all authenticated requests. This will take precedence over any other authorizer.")
+
+	fs.BoolVar(&s.Webhook, "authorization-webhook", s.Webhook,
+		"Whether to use a webhook to authorize requests.")
+	fs.StringVar(&s.WebhookConfigFile, "authorization-webhook-config-file", s.WebhookConfigFile,
+		"File with webhook configuration in kubeconfig format, used with --authorization-webhook=true. "+
+			"The API server will query the remote service to determine access on the API server's secure port.")
+
+	// TODO: Uncomment these when https://github.com/kubernetes/cluster-registry/issues/69
+	// is fixed, and there is a unique standalone personality for the clusterregistry.
+	//fs.DurationVar(&s.WebhookCacheAuthorizedTTL, "authorization-webhook-cache-authorized-ttl",
+	//	s.WebhookCacheAuthorizedTTL,
+	//	"The duration to cache 'authorized' responses from the webhook authorizer.")
+	//fs.DurationVar(&s.WebhookCacheUnauthorizedTTL,
+	//	"authorization-webhook-cache-unauthorized-ttl", s.WebhookCacheUnauthorizedTTL,
+	//	"The duration to cache 'unauthorized' responses from the webhook authorizer.")
 }
 
+// ApplyTo applies the configured options in the receiver to an apiserver
+// Config.
 func (s *StandaloneAuthorizationOptions) ApplyTo(c *genericapiserver.Config) error {
 	authorizer, err := s.toAuthorizationConfig().New()
 	if err != nil {
@@ -66,5 +137,11 @@ func (s *StandaloneAuthorizationOptions) ApplyTo(c *genericapiserver.Config) err
 }
 
 func (s *StandaloneAuthorizationOptions) toAuthorizationConfig() StandaloneAuthorizerConfig {
-	return StandaloneAuthorizerConfig{AlwaysAllow: s.AlwaysAllow}
+	return StandaloneAuthorizerConfig{
+		AlwaysAllow:                 s.AlwaysAllow,
+		Webhook:                     s.Webhook,
+		WebhookConfigFile:           s.WebhookConfigFile,
+		WebhookCacheAuthorizedTTL:   s.WebhookCacheAuthorizedTTL,
+		WebhookCacheUnauthorizedTTL: s.WebhookCacheUnauthorizedTTL,
+	}
 }


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

Also adds an example using a webhook for authorization.

Fixes #46.

/cc @font @pmorie @madhusudancs 