### PR TITLE
Change the default clusterregistry image deployed by crinit

### DIFF
--- a/cmd/crinit/crinit.go
+++ b/cmd/crinit/crinit.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	clusterregistryImageName = "clusterregistry:dev"
+	clusterregistryImageName = "gcr.io/crreleases/clusterregistry:latest"
 	defaultEtcdImage         = "k8s.gcr.io/etcd:3.0.17"
 )
 


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster
