### PR TITLE
Add repo-infra scripts to verify go source code

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -116,6 +116,21 @@ generated clients and other generated files.
 1.  Add the generated files to your PR, preferably in a separate, generated-only
     commit so that they are easier to review.
 
+## Verify Go source files
+
+To verify and fix your Go source files:
+
+1. Run from the root of this repository `./hack/verify-go-src.sh -v --rootdir $(pwd)`
+
+This runs all the Go source verification scripts in
+[`./hack/go-tools/`](/hack/go-tools/).
+
+You can also run any of the scripts individually. For example:
+
+1. Run `./hack/go-tools/verify-govet.sh`
+
+The return code of the script indicates success or failure.
+
 ## Interacting with the k8s-bot
 
 The cluster-registry repo is monitored by the k8s-ci-robot. You can find a list

--- a/hack/go-tools/verify-gofmt.sh
+++ b/hack/go-tools/verify-gofmt.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename '*/vendor/*' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+GOFMT="gofmt -s"
+bad_files=$(find_files | xargs $GOFMT -l)
+if [[ -n "${bad_files}" ]]; then
+  echo "!!! '$GOFMT' needs to be run on the following files: "
+  echo "${bad_files}"
+  exit 1
+fi

--- a/hack/go-tools/verify-govet.sh
+++ b/hack/go-tools/verify-govet.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+go vet -v $(go list ./... | grep -v /vendor/)

--- a/hack/verify-go-src.sh
+++ b/hack/verify-go-src.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# This script is intended to be used via subtree in a top-level directory:
+# <repo>/
+#  repo-infra/
+#    verify/
+# Or via vendoring and passing root directory as vendor/repo-infra/verify-*.sh --rootdir **full path to your repo dir**
+# <repo>/
+#   vendor/
+#      repo-infra/
+#         ...
+# 
+
+
+SILENT=true
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+
+# Convert long opts to short ones to read through getopts
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--rootdir") set -- "$@" "-r";;
+    *)
+      set -- "$@" "$arg"
+      ;;
+  esac
+done
+
+OPTIND=1
+while getopts "vr:" opt; do
+  case ${opt} in
+    v)
+      SILENT=false
+      ;;
+    r)
+      REPO_ROOT=${OPTARG}
+      ;;
+    \?)
+      echo "Invalid flag: -${OPTARG}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+shift "$(($OPTIND-1))"
+
+echo "Working directory: ${REPO_ROOT}"
+
+GO_TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/go-tools"
+
+function run-cmd {
+  if ${SILENT}; then
+    "$@" &> /dev/null
+  else
+    "$@"
+  fi
+}
+
+# Some useful colors.
+if [[ -z "${color_start-}" ]]; then
+  declare -r color_start="\033["
+  declare -r color_red="${color_start}0;31m"
+  declare -r color_yellow="${color_start}0;33m"
+  declare -r color_green="${color_start}0;32m"
+  declare -r color_norm="${color_start}0m"
+fi
+
+function run-checks {
+  local -r pattern=$1
+  local -r runner=$2
+
+  for t in $(ls ${pattern})
+  do
+    echo -e "Verifying ${t}"
+    local start=$(date +%s)
+    cd $REPO_ROOT && run-cmd "${runner}" "${t}" && tr=$? || tr=$?
+    local elapsed=$(($(date +%s) - ${start}))
+    if [[ ${tr} -eq 0 ]]; then
+      echo -e "${color_green}SUCCESS${color_norm}  ${t}\t${elapsed}s"
+    else
+      echo -e "${color_red}FAILED${color_norm}   ${t}\t${elapsed}s"
+      ret=1
+    fi
+  done
+}
+
+if ${SILENT} ; then
+  echo "Running in silent mode, run with -v if you want to see script logs."
+fi
+
+ret=0
+run-checks "${GO_TOOLS_DIR}/*.sh" bash
+exit ${ret}

--- a/pkg/crinit/aggregated/aggregated.go
+++ b/pkg/crinit/aggregated/aggregated.go
@@ -377,7 +377,7 @@ func createClusterRoleBindingObject(clientset client.Interface, name, subjectKin
 			Labels: labels,
 		},
 		Subjects: []rbacv1.Subject{
-			rbacv1.Subject{
+			{
 				Kind:      subjectKind,
 				Name:      subjectName,
 				Namespace: subjectNamespace,
@@ -407,7 +407,7 @@ func createExtensionAPIServerAuthenticationRoleBinding(clientset client.Interfac
 			Labels: util.ComponentLabel,
 		},
 		Subjects: []rbacv1.Subject{
-			rbacv1.Subject{
+			{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      serviceAccountName,
 				Namespace: namespace,

--- a/pkg/crinit/standalone/standalone_test.go
+++ b/pkg/crinit/standalone/standalone_test.go
@@ -298,7 +298,7 @@ func TestCreateService(t *testing.T) {
 		},
 		Status: v1.NodeStatus{
 			Addresses: []v1.NodeAddress{
-				v1.NodeAddress{
+				{
 					Type:    v1.NodeExternalIP,
 					Address: "200.0.0.1",
 				},
@@ -353,7 +353,7 @@ func TestCreateService(t *testing.T) {
 				createAction := action.(clientgotesting.CreateAction)
 				svc := createAction.GetObject().(*v1.Service)
 				if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
-					svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{v1.LoadBalancerIngress{IP: loadBalancerAddress, Hostname: loadBalancerHostname}}
+					svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{IP: loadBalancerAddress, Hostname: loadBalancerHostname}}
 					return false, svc, nil
 				}
 				return false, nil, nil
@@ -434,7 +434,7 @@ func TestGetClusterNodeIPs(t *testing.T) {
 		},
 		Status: v1.NodeStatus{
 			Addresses: []v1.NodeAddress{
-				v1.NodeAddress{
+				{
 					Type:    v1.NodeExternalIP,
 					Address: "200.0.0.1",
 				},
@@ -448,7 +448,7 @@ func TestGetClusterNodeIPs(t *testing.T) {
 		},
 		Status: v1.NodeStatus{
 			Addresses: []v1.NodeAddress{
-				v1.NodeAddress{
+				{
 					Type:    v1.NodeInternalIP,
 					Address: "10.0.0.1",
 				},
@@ -462,11 +462,11 @@ func TestGetClusterNodeIPs(t *testing.T) {
 		},
 		Status: v1.NodeStatus{
 			Addresses: []v1.NodeAddress{
-				v1.NodeAddress{
+				{
 					Type:    v1.NodeExternalIP,
 					Address: "200.0.0.2",
 				},
-				v1.NodeAddress{
+				{
 					Type:    v1.NodeInternalIP,
 					Address: "10.0.0.2",
 				},


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->
Adding scripts from [repo-infra](https://github.com/kubernetes/repo-infra/tree/0aafaab9e158d3628804242c6a9c4dd3eb8bce1f/verify) to help verify go source code. It would be best to vendor in the scripts to execute them directly, but we are blocked on https://github.com/golang/dep/issues/1306.

The first commit adds the scripts and the second commit fixes the errors.

This can be followed up with a prow job.

/sig multicluster
