### PR TITLE
Update and simplify Go source file verification scripts

### DIFF
--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
    "title": "Cluster Registry",
-   "version": "v0.0.1"
+   "version": "v0.0.2"
   },
   "paths": {
    "/apis/": {

--- a/docs/development.md
+++ b/docs/development.md
@@ -118,9 +118,10 @@ generated clients and other generated files.
 
 ## Verify Go source files
 
-To verify and fix your Go source files:
+You can run the Go source file verification script to verify and fix your Go source
+files:
 
-1. Run from the root of this repository `./hack/verify-go-src.sh -v --rootdir $(pwd)`
+1. Run `./hack/verify-go-src.sh`
 
 This runs all the Go source verification scripts in
 [`./hack/go-tools/`](/hack/go-tools/).

--- a/hack/go-tools/verify-gofmt.sh
+++ b/hack/go-tools/verify-gofmt.sh
@@ -15,6 +15,10 @@
 
 set -euo pipefail
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_ROOT}/../.." && pwd)"
+pushd ${REPO_ROOT} > /dev/null
+
 find_files() {
   find . -not \( \
       \( \
@@ -25,6 +29,8 @@ find_files() {
 
 GOFMT="gofmt -s"
 bad_files=$(find_files | xargs $GOFMT -l)
+popd > /dev/null
+
 if [[ -n "${bad_files}" ]]; then
   echo "!!! '$GOFMT' needs to be run on the following files: "
   echo "${bad_files}"

--- a/hack/go-tools/verify-govet.sh
+++ b/hack/go-tools/verify-govet.sh
@@ -15,4 +15,8 @@
 
 set -euo pipefail
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_ROOT}/../.." && pwd)"
+pushd ${REPO_ROOT} > /dev/null
 go vet -v $(go list ./... | grep -v /vendor/)
+popd > /dev/null

--- a/pkg/crinit/aggregated/aggregated.go
+++ b/pkg/crinit/aggregated/aggregated.go
@@ -32,9 +32,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
-	"k8s.io/cluster-registry/pkg/crinit/util"
-	"k8s.io/cluster-registry/pkg/crinit/options"
 	"k8s.io/cluster-registry/pkg/crinit/common"
+	"k8s.io/cluster-registry/pkg/crinit/options"
+	"k8s.io/cluster-registry/pkg/crinit/util"
 	apiregv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	apiregclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 

--- a/pkg/crinit/common/common.go
+++ b/pkg/crinit/common/common.go
@@ -62,8 +62,6 @@ var (
 	}
 )
 
-
-
 // CreateNamespace helper to create the cluster registry namespace object and return
 // the object.
 func CreateNamespace(clientset client.Interface, namespace string,
@@ -85,7 +83,7 @@ func CreateNamespace(clientset client.Interface, namespace string,
 // and return the object. If service type is load balancer, will wait for load
 // balancer IP and return it and hostnames.
 func CreateService(cmdOut io.Writer, clientset client.Interface, namespace,
-svcName, apiserverAdvertiseAddress string, apiserverPort *int32,
+	svcName, apiserverAdvertiseAddress string, apiserverPort *int32,
 	apiserverServiceType v1.ServiceType,
 	dryRun bool) (*v1.Service, []string, []string, error) {
 
@@ -171,7 +169,7 @@ func GetClusterNodeIPs(clientset client.Interface) ([]string, error) {
 // CreateAPIServerCredentialsSecret helper to create secret object and return
 // the object.
 func CreateAPIServerCredentialsSecret(clientset client.Interface, namespace,
-credentialsName string, credentials *util.Credentials, dryRun bool) (*v1.Secret, error) {
+	credentialsName string, credentials *util.Credentials, dryRun bool) (*v1.Secret, error) {
 	// Build the secret object with API server credentials.
 	data := map[string][]byte{
 		"ca.crt":     certutil.EncodeCertPEM(credentials.CertEntKeyPairs.CA.Cert),
@@ -203,7 +201,7 @@ credentialsName string, credentials *util.Credentials, dryRun bool) (*v1.Secret,
 // CreatePVC helper to create the persistent volume claim object and
 // return the object.
 func CreatePVC(clientset client.Interface, namespace, svcName, etcdPVCapacity,
-etcdPVStorageClass string, dryRun bool) (*v1.PersistentVolumeClaim, error) {
+	etcdPVStorageClass string, dryRun bool) (*v1.PersistentVolumeClaim, error) {
 	capacity, err := resource.ParseQuantity(etcdPVCapacity)
 	if err != nil {
 		return nil, err
@@ -243,8 +241,8 @@ etcdPVStorageClass string, dryRun bool) (*v1.PersistentVolumeClaim, error) {
 // CreateAPIServer helper to create the apiserver deployment object and
 // return the object.
 func CreateAPIServer(clientset client.Interface, namespace, name, serverImage,
-etcdImage, advertiseAddress, credentialsName, serviceAccountName string, hasHTTPBasicAuthFile,
-hasTokenAuthFile bool, argOverrides map[string]string,
+	etcdImage, advertiseAddress, credentialsName, serviceAccountName string, hasHTTPBasicAuthFile,
+	hasTokenAuthFile bool, argOverrides map[string]string,
 	pvc *v1.PersistentVolumeClaim, aggregated, dryRun bool) (*appsv1beta1.Deployment, error) {
 
 	command := []string{"./clusterregistry"}

--- a/pkg/crinit/options/options.go
+++ b/pkg/crinit/options/options.go
@@ -18,20 +18,19 @@ limitations under the License.
 package options
 
 import (
-	"net"
-	"io"
-	"strings"
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
-	"strconv"
+	"io"
 	"k8s.io/api/core/v1"
+	"net"
+	"strconv"
+	"strings"
 
 	client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/cluster-registry/pkg/crinit/common"
 	"k8s.io/cluster-registry/pkg/crinit/util"
-
 )
 
 const (
@@ -39,9 +38,9 @@ const (
 	// cluster registry components are hosted.
 	DefaultClusterRegistryNamespace = "clusterregistry"
 
-	HostClusterLocalDNSZoneName     = "cluster.local."
-	APIServerNameSuffix             = "apiserver"
-	CredentialSuffix                = "credentials"
+	HostClusterLocalDNSZoneName = "cluster.local."
+	APIServerNameSuffix         = "apiserver"
+	CredentialSuffix            = "credentials"
 
 	APIServerAdvertiseAddressFlag = "api-server-advertise-address"
 	APIServerServiceTypeFlag      = "api-server-service-type"
@@ -199,7 +198,6 @@ func (o *SubcommandOptions) CreateNamespace(cmdOut io.Writer,
 	fmt.Fprintln(cmdOut, " done")
 	return err
 }
-
 
 // CreateService creates the cluster registry apiserver service.
 func (o *SubcommandOptions) CreateService(cmdOut io.Writer,

--- a/pkg/crinit/standalone/standalone.go
+++ b/pkg/crinit/standalone/standalone.go
@@ -25,8 +25,8 @@ import (
 	"k8s.io/api/core/v1"
 	client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/cluster-registry/pkg/crinit/util"
 	"k8s.io/cluster-registry/pkg/crinit/options"
+	"k8s.io/cluster-registry/pkg/crinit/util"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"

--- a/pkg/crinit/standalone/standalone_test.go
+++ b/pkg/crinit/standalone/standalone_test.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
-	"k8s.io/cluster-registry/pkg/crinit/options"
 	"k8s.io/cluster-registry/pkg/crinit/common"
+	"k8s.io/cluster-registry/pkg/crinit/options"
 )
 
 func TestValidateOptions(t *testing.T) {
@@ -69,7 +69,7 @@ func TestValidateOptions(t *testing.T) {
 			desc: "advertise address supported with NodePort service type",
 			initialOpts: &standaloneClusterRegistryOptions{
 				apiServerServiceTypeString: string(v1.ServiceTypeNodePort),
-		SubcommandOptions: options.SubcommandOptions{
+				SubcommandOptions: options.SubcommandOptions{
 					APIServerAdvertiseAddress: "10.0.0.1"}},
 			errExpected: false,
 		},

--- a/pkg/crinit/util/util.go
+++ b/pkg/crinit/util/util.go
@@ -24,13 +24,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/cert/triple"
-	"github.com/golang/glog"
 )
 
 const (
@@ -111,7 +111,7 @@ func ArgMapsToArgStrings(argsMap, overrides map[string]string) []string {
 // UpdateKubeconfig helper to update the kubeconfig file based on input
 // parameters.
 func UpdateKubeconfig(pathOptions *clientcmd.PathOptions, name, endpoint,
-kubeConfigPath string, credentials *Credentials, dryRun bool) error {
+	kubeConfigPath string, credentials *Credentials, dryRun bool) error {
 
 	pathOptions.LoadingRules.ExplicitPath = kubeConfigPath
 	kubeconfig, err := pathOptions.GetStartingConfig()


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

- Update OpenAPI spec after cluster registry v0.0.2 released.

- Updated the script that runs all Go source file verify scripts to not take any arguments. This helps simplify it, easier to document it, and easier to run as a Prow job.

- Also updated individual verify scripts to allow being run from any directory.

- Fixed the `gofmt` errors.


/sig multicluster
