### PR TITLE
Remove the bootstrap token logic from the cluster registry.

### DIFF
--- a/pkg/clusterregistry/authenticator/config.go
+++ b/pkg/clusterregistry/authenticator/config.go
@@ -57,10 +57,6 @@ type Config struct {
 	// BasicAuthFile is a path to a file that contains username/password pairs.
 	BasicAuthFile string
 
-	// BootstrapToken determines whether or not to enable authentication via
-	// BootstrapTokenAuthenticator.
-	BootstrapToken bool
-
 	// ClientCAFile is a path to a certificate that can be used to validate
 	// client certificates.
 	ClientCAFile string
@@ -85,10 +81,6 @@ type Config struct {
 	// RequestHeaderConfig contains information about authenticating via request
 	// headers.
 	RequestHeaderConfig *authenticatorfactory.RequestHeaderConfig
-
-	// BootstrapTokenAuthenticator is a token authenticator specifically for tokens
-	// used to bootstrap a cluster registry.
-	BootstrapTokenAuthenticator authenticator.Token
 }
 
 // New returns an authenticator.Request or an error that supports the standard
@@ -140,13 +132,6 @@ func (config Config) New() (authenticator.Request, *spec.SecurityDefinitions, er
 			return nil, nil, err
 		}
 		tokenAuthenticators = append(tokenAuthenticators, tokenAuth)
-	}
-
-	if config.BootstrapToken {
-		if config.BootstrapTokenAuthenticator != nil {
-			// TODO: This can sometimes be nil because of
-			tokenAuthenticators = append(tokenAuthenticators, config.BootstrapTokenAuthenticator)
-		}
 	}
 
 	if len(config.WebhookTokenAuthnConfigFile) > 0 {

--- a/pkg/clusterregistry/options/authentication.go
+++ b/pkg/clusterregistry/options/authentication.go
@@ -29,12 +29,11 @@ import (
 )
 
 type StandaloneAuthenticationOptions struct {
-	Anonymous      *AnonymousAuthenticationOptions
-	BootstrapToken *BootstrapTokenAuthenticationOptions
-	ClientCert     *genericoptions.ClientCertAuthenticationOptions
-	PasswordFile   *PasswordFileAuthenticationOptions
-	TokenFile      *TokenFileAuthenticationOptions
-	WebHook        *WebHookAuthenticationOptions
+	Anonymous    *AnonymousAuthenticationOptions
+	ClientCert   *genericoptions.ClientCertAuthenticationOptions
+	PasswordFile *PasswordFileAuthenticationOptions
+	TokenFile    *TokenFileAuthenticationOptions
+	WebHook      *WebHookAuthenticationOptions
 
 	TokenSuccessCacheTTL time.Duration
 	TokenFailureCacheTTL time.Duration
@@ -42,10 +41,6 @@ type StandaloneAuthenticationOptions struct {
 
 type AnonymousAuthenticationOptions struct {
 	Allow bool
-}
-
-type BootstrapTokenAuthenticationOptions struct {
-	Enable bool
 }
 
 type PasswordFileAuthenticationOptions struct {
@@ -71,7 +66,6 @@ func NewStandaloneAuthenticationOptions() *StandaloneAuthenticationOptions {
 func (s *StandaloneAuthenticationOptions) WithAll() *StandaloneAuthenticationOptions {
 	return s.
 		WithAnonymous().
-		WithBootstrapToken().
 		WithClientCert().
 		WithPasswordFile().
 		WithTokenFile().
@@ -80,11 +74,6 @@ func (s *StandaloneAuthenticationOptions) WithAll() *StandaloneAuthenticationOpt
 
 func (s *StandaloneAuthenticationOptions) WithAnonymous() *StandaloneAuthenticationOptions {
 	s.Anonymous = &AnonymousAuthenticationOptions{Allow: true}
-	return s
-}
-
-func (s *StandaloneAuthenticationOptions) WithBootstrapToken() *StandaloneAuthenticationOptions {
-	s.BootstrapToken = &BootstrapTokenAuthenticationOptions{}
 	return s
 }
 
@@ -121,16 +110,6 @@ func (s *StandaloneAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 			"Enables anonymous requests to the secure port of the API server. "+
 			"Requests that are not rejected by another authentication method are treated as anonymous requests. "+
 			"Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated.")
-	}
-
-	if s.BootstrapToken != nil {
-		fs.BoolVar(&s.BootstrapToken.Enable, "experimental-bootstrap-token-auth", s.BootstrapToken.Enable, ""+
-			"Deprecated (use --enable-bootstrap-token-auth).")
-		fs.MarkDeprecated("experimental-bootstrap-token-auth", "use --enable-bootstrap-token-auth instead.")
-
-		fs.BoolVar(&s.BootstrapToken.Enable, "enable-bootstrap-token-auth", s.BootstrapToken.Enable, ""+
-			"Enable to allow secrets of type 'bootstrap.kubernetes.io/token' in the 'kube-system' "+
-			"namespace to be used for TLS bootstrapping authentication.")
 	}
 
 	if s.ClientCert != nil {
@@ -189,10 +168,6 @@ func (s *StandaloneAuthenticationOptions) toAuthenticationConfig() authenticator
 
 	if s.Anonymous != nil {
 		ret.Anonymous = s.Anonymous.Allow
-	}
-
-	if s.BootstrapToken != nil {
-		ret.BootstrapToken = s.BootstrapToken.Enable
 	}
 
 	if s.ClientCert != nil {


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

I don't think there's a need for this for the cluster registry, considering it's not actually trying to bootstrap nodes into a cluster. If there is in the future, it's easier to add it back.

/cc @font @madhusudancs @pmorie