### PR TITLE
Fix crinit standalone deployment

### DIFF
--- a/pkg/crinit/common/common.go
+++ b/pkg/crinit/common/common.go
@@ -265,10 +265,13 @@ func CreateAPIServer(clientset client.Interface, namespace, name, serverImage,
 		argsMap["--token-auth-file"] = "/etc/clusterregistry/apiserver/token.csv"
 	}
 
-	args := util.ArgMapsToArgStrings(argsMap, argOverrides)
 	if aggregated {
 		command = append(command, "aggregated")
+	} else {
+		command = append(command, "standalone")
 	}
+
+	args := util.ArgMapsToArgStrings(argsMap, argOverrides)
 	command = append(command, args...)
 
 	replicas := int32(1)


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

This went into v0.0.2 with the recent `crinit` refactor, so we'll need to release v0.0.3.

/sig multicluster
