### PR TITLE
Improve crinit's handling of waiting for the cluster registry API server.

### DIFF
--- a/pkg/crinit/aggregated/BUILD.bazel
+++ b/pkg/crinit/aggregated/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/clusterregistry/v1alpha1:go_default_library",
+        "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/crinit/common:go_default_library",
         "//pkg/crinit/options:go_default_library",
         "//pkg/crinit/util:go_default_library",
@@ -16,6 +17,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

/cc @madhusudancs @pmorie @font 

Also, adds reasonable timeouts for the `Waiting for API server...` operations.

Addresses #118. Also filed #187 as a result of this work to think holistically about how to give troubleshooting help when `crinit` fails.