### PR TITLE
Fix clusterregistry.k8s.io:apiserver ClusterRole

### DIFF
--- a/pkg/crinit/aggregated/aggregated.go
+++ b/pkg/crinit/aggregated/aggregated.go
@@ -53,7 +53,7 @@ var (
 
 	// The list of our cluster registry API resources to which the rule applies
 	// in the cluster role object.
-	clusterRoleResources = []string{"cluster"}
+	clusterRoleResources = []string{"clusters"}
 
 	// The list of verbs that apply to our cluster registry API resources.
 	clusterRoleVerbs = []string{"get", "list", "watch", "create", "update", "patch", "delete"}


### PR DESCRIPTION
I discovered this when I attempted to create a new `ClusterRoleBinding` referencing this `ClusterRole`. Until I changed from `cluster` to `clusters`, it didn't work.

Before:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
    app: clusterregistry
  name: clusterregistry.k8s.io:apiserver
rules:
- apiGroups:
  - clusterregistry.k8s.io
  resources:
  - cluster
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
  - delete
```

After (only change is `clusters` under `resources`):

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
    app: clusterregistry
  name: clusterregistry.k8s.io:apiserver
rules:
- apiGroups:
  - clusterregistry.k8s.io
  resources:
  - clusters
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
  - delete
```

This brings up another question. What is the purpose of this `ClusterRole`? It's bound to the `ServiceAccount` in the `ClusterRoleBinding` of the same name but I'm not familiar with when that would be used. Any instruction here would be appreciated.

<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster
