### PR TITLE
Remove cluster role and binding for clusters

### DIFF
--- a/pkg/crinit/aggregated/aggregated.go
+++ b/pkg/crinit/aggregated/aggregated.go
@@ -42,26 +42,6 @@ var (
 	// with our cluster role objects.
 	serviceAccountName = strings.Replace(v1alpha1.GroupName, ".", "-", -1) + "-apiserver"
 
-	// Name used for our cluster role object to subsequently specify what
-	// operations we want to allow on our API resources via cluster role
-	// bindings.
-	clusterRoleName = v1alpha1.GroupName + ":apiserver"
-
-	// The name of our cluster registry API group used in the creation of the
-	// cluster role binding.
-	clusterRoleAPIGroup = []string{v1alpha1.GroupName}
-
-	// The list of our cluster registry API resources to which the rule applies
-	// in the cluster role object.
-	clusterRoleResources = []string{"clusters"}
-
-	// The list of verbs that apply to our cluster registry API resources.
-	clusterRoleVerbs = []string{"get", "list", "watch", "create", "update", "patch", "delete"}
-
-	// Name used for our cluster registry cluster role binding (CRB) object to
-	// specify the operations we want to allow on our API resources.
-	apiServerCRBName = v1alpha1.GroupName + ":apiserver"
-
 	// Name used for our cluster registry cluster role binding (CRB) object that
 	// allows delegated authentication and authorization checks.
 	authDelegatorCRBName = v1alpha1.GroupName + ":apiserver-auth-delegator"


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

Remove unnecessary cluster role and cluster role binding objects as I don't think we'll need it. This is mainly used to provide permissions for controllers within the cluster to perform specific cluster operations e.g. an admission controller to perform specific cluster resource operations. This cleans up and simplifies the code a bit. We can always add it back later if needed.

The [k8s docs on this](https://kubernetes.io/docs/tasks/access-kubernetes-api/setup-extension-api-server/) are a little misleading and suggest this is needed.

/sig multicluster
