### PR TITLE
Fix the cp command

### DIFF
--- a/examples/samplecontainer/README.md
+++ b/examples/samplecontainer/README.md
@@ -12,8 +12,8 @@ To build, from this directory, run:
 
 ```sh
 bazel build //cmd/clusterregistry //examples/slackcontroller
-cp "$(bazel info bazel-bin)/cmd/clusterregistry/clusterregistry" \
-  "$(bazel info bazel-bin)/examples/slackcontroller/slackcontroller" \
+cp "$(bazel info bazel-bin)/cmd/clusterregistry/$(go env GOHOSTOS)_$(go env GOARCH)_stripped/clusterregistry" \
+  "$(bazel info bazel-bin)/examples/slackcontroller/$(go env GOHOSTOS)_$(go env GOARCH)_stripped/slackcontroller" \
   ./contents
 docker build . -t crexample:latest
 ```


### PR DESCRIPTION
   fix location of binaries

<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

The  examples/samplecontainer/README.md file has the following command
cp "$(bazel info bazel-bin)/cmd/clusterregistry/clusterregistry" \ "$(bazel info bazel-bin)/examples/slackcontroller/slackcontroller" \ ./contents

However, the binaries are located in the OS and ARCH dependent path.

On my MAC they are
`$(bazel info bazel-bin)/cmd/clusterregistry/darwin_amd64_stripped/clusterregistry"` and
`$(bazel info bazel-bin)/examples/slackcontroller/darwin_amd64_stripped/slackcontroller"`

Issue #226 