### PR TITLE
Some small updates to the cluster CRD YAML

### DIFF
--- a/cluster-registry-crd.yaml
+++ b/cluster-registry-crd.yaml
@@ -1,6 +1,10 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
+  labels:
+    api: ""
+    kubebuilder.k8s.io: 0.1.9
   name: clusters.clusterregistry.k8s.io
 spec:
   group: clusterregistry.k8s.io
@@ -67,3 +71,8 @@ spec:
           type: object
       type: object
   version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null

--- a/cluster-registry-crd.yaml
+++ b/cluster-registry-crd.yaml
@@ -35,7 +35,7 @@ spec:
                 caBundle:
                   items:
                     type: byte
-                  type: array
+                  type: string
                 serverEndpoints:
                   items:
                     properties:

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,6 +62,10 @@ These will update the generated client code, update the generated docs and
 OpenAPI spec in `docs/reference/openapi-spec`, and update the CRD YAML
 definition in the repo root.
 
+After running the commands, edit `cluster-registry-crd.yaml` to modify the
+`type` of the `caBundle` field from `array` to `string`. (See
+https://github.com/kubernetes-sigs/kubebuilder/issues/220 for more details).
+
 ## Verify Go source files
 
 You can run the Go source file verification script to verify and fix your Go

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,9 +62,6 @@ These will update the generated client code, update the generated docs and
 OpenAPI spec in `docs/reference/openapi-spec`, and update the CRD YAML
 definition in the repo root.
 
-After running the commands, edit `cluster-registry-crd.yaml` to remove the
-`status` field, and the `creationTimestamp` and `labels` from the `metadata`.
-
 ## Verify Go source files
 
 You can run the Go source file verification script to verify and fix your Go


### PR DESCRIPTION
<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

- leave all the generated fields in the YAML, to make the process of generating and updating simpler
- fix a bug with the generated YAML. https://github.com/kubernetes-sigs/kubebuilder/issues/220 tracks fixing this issue upstream.

/assign @pmorie @madhusudancs @font 