### PR TITLE
Fix a missing 'omitempty' tag.

### DIFF
--- a/cluster-registry-crd.yaml
+++ b/cluster-registry-crd.yaml
@@ -85,8 +85,6 @@ spec:
                 type: object
               type: array
           type: object
-      required:
-      - status
       type: object
   version: v1alpha1
 status:

--- a/pkg/apis/clusterregistry/v1alpha1/types.go
+++ b/pkg/apis/clusterregistry/v1alpha1/types.go
@@ -41,7 +41,7 @@ type Cluster struct {
 
 	// Status is the status of the cluster.
 	// +optional
-	Status ClusterStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
+	Status ClusterStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // ClusterSpec contains the specification of a cluster.

--- a/pkg/apis/clusterregistry/v1alpha1/zz_generated.kubebuilder.go
+++ b/pkg/apis/clusterregistry/v1alpha1/zz_generated.kubebuilder.go
@@ -197,9 +197,7 @@ var (
 							},
 						},
 					},
-					Required: []string{
-						"status",
-					}},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The Cluster's Status field was missing the 'omitempty' tag, which caused
the generation machinery to mark it as required. It should be optional.

<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/cc @madhusudancs @font @pmorie 
/sig multicluster
