### PR TITLE
Fix typos in the files

### DIFF
--- a/docs/reference/build/README.md
+++ b/docs/reference/build/README.md
@@ -66,4 +66,4 @@ Apache License Version 2.0
 ## FAQ
 
 Q: Why is it named brodocs?
-A: This project was born out of a collaboration with my brother to create a suitable docs app for his purposes. It was a fun name for the the two of us to use as actual brothers.
+A: This project was born out of a collaboration with my brother to create a suitable docs app for his purposes. It was a fun name for the two of us to use as actual brothers.

--- a/docs/reference/build/scroll.js
+++ b/docs/reference/build/scroll.js
@@ -65,7 +65,7 @@ $(document).ready(function() {
             currL1Nav = getNavNode(activeSection.token);
             currL1Nav.show('fast');
         } 
-        // If active active is not the same as previous, hide previous L1Nav and show current L1Nav; set previous to current
+        // If active is not the same as previous, hide previous L1Nav and show current L1Nav; set previous to current
         else if (activeSection.token !== prevSectionToken) {
             prevL1Nav = getNavNode(prevSectionToken);
             currL1Nav = getNavNode(activeSection.token);

--- a/hack/imports.go
+++ b/hack/imports.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package hack
-
 /*
 Package imports dependencies required for "dep ensure" to fetch all of the go package dependencies needed
 by kubebuilder commands to work without rerunning "dep ensure".
@@ -26,4 +24,6 @@ dep ensure doesn't need to be rerun after "kubebuilder create resource".
 This is necessary for subsequent commands - such as building docs, tests, etc - to work without rerunning "dep ensure"
 afterward.
 */
+package hack
+
 import _ "github.com/kubernetes-sigs/kubebuilder/pkg/imports"

--- a/hack/imports.go
+++ b/hack/imports.go
@@ -17,7 +17,7 @@ limitations under the License.
 package hack
 
 /*
-Package imports imports dependencies required for "dep ensure" to fetch all of the go package dependencies needed
+Package imports dependencies required for "dep ensure" to fetch all of the go package dependencies needed
 by kubebuilder commands to work without rerunning "dep ensure".
 
 Example: make sure the testing libraries and apimachinery libraries are fetched by "dep ensure" so that


### PR DESCRIPTION
Signed-off-by: mooncake <xcoder@tenxcloud.com>

<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster

Fix typos in below files:

1. docs/reference/build/README.md
2. docs/reference/build/scroll.js
3. hack/imports.go

