### PR TITLE
Update to k8s-ci-robot's command list

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -92,7 +92,7 @@ The return code of the script indicates success or failure.
 
 The cluster-registry repo is monitored by the k8s-ci-robot. You can find a list
 of the commands it accepts
-[here](https://github.com/kubernetes/test-infra/blob/master/commands.md). Note
+[here](https://go.k8s.io/bot-commands). Note
 that some of the commands are not relevant for the cluster registry, namely as
 `/approve`, `/area`, `/hold`, `/release-note` and `/status`.
 


### PR DESCRIPTION
The previous link was broken

<!-- Labels this issue with the sig/multicluster label. Please do not remove. -->

/sig multicluster
